### PR TITLE
aria added

### DIFF
--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -5,7 +5,7 @@
 
     <div class="hotgraphic-graphic">
 
-      <div class="hotgraphic-popup" role="dialog">
+      <div class="hotgraphic-popup" role="dialog" aria-label="{{_accessibility._ariaLabels.hotgraphicPopUp}}">
 
         <div class="hotgraphic-popup-toolbar component-item-color clearfix">
           <div class="hotgraphic-popup-nav component-item-color">


### PR DESCRIPTION
Aria added to popup for triggered dialog. Label to contain user instruction for reading content. Fixes auto read issue with content limit and dialog cutting out. (previous JAWS issue).
