### PR TITLE
Tweaks to allow images as hot graphic pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This defines the position of the component in the block. Values can be `full`, `
 
 Hides the previous and next actions and progress indicator from the toolbar.
 
+####_useGraphicsAsPins
+
+When this is set to true, the item graphics can be used as 'pins'.  When this is set to 'false' (per default), a main poster image is displayed, with pins overlayed to trigger the hot spots.
+
 ####mobileBody
 
 This is optional body text that will be shown when viewed on mobile.
@@ -66,6 +70,8 @@ Title text can be entered here for the image.
 ####_items
 
 Multiple items can be entered. Each item represents one hot spot for this component and contains values for `title`, `body` and `_graphic`.
+
+Within _graphic, 'src', 'title', 'alt' and '_classes' can be set.
 
 ####title
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "authors": [
     "Kevin Corry <kevinc@learningpool.com>"

--- a/example.json
+++ b/example.json
@@ -10,6 +10,7 @@
       "body": "This is optional body text. Select the hotspots on the image to reveal the text. This component will scale down to a narrative when viewed on mobile.",
       "mobileBody": "This is optional body text that will be shown when viewed on mobile.",
       "instruction":"",
+      "_pinNarrative": true, // if true it will use the pins as graphics instead of the large graphic
       "_graphic": {
         "src": "hot_graphic.jpg",
         "alt": "alt text",
@@ -22,9 +23,11 @@
             "_graphic": {
                 "src": "image1.jpg",
                 "alt": "alt text",
-                "title": "title text"
+                "title": "title text",
+                "_classes": "cols-2 rows-1" // Image will be 2 blocks wide, 1 block high
             },
             "strapline": "strapline...",
+            "_classes": "top-left", // Position to display the popup
             "_top": 5,
             "_left": 20
         },
@@ -34,9 +37,11 @@
             "_graphic": {
                 "src": "image2.jpg",
                 "alt": "alt text",
-                "title": "title text"
+                "title": "title text",
+                "_classes": "cols-2 rows-1" // Image will be 2 blocks wide, 1 block high
             },
             "strapline": "strapline...",
+            "_classes": "center",
             "_top": 25,
             "_left": 60
         },
@@ -46,9 +51,11 @@
             "_graphic": {
                 "src": "image3.jpg",
                 "alt": "alt text",
-                "title": "title text"
+                "title": "title text",
+                "_classes": "cols-1 rows-1" // Image will be 2 blocks wide, 1 block high
             },
             "strapline": "strapline...",
+            "_classes": "bottom-right",
             "_top": 85,
             "_left": 40
         }

--- a/example.json
+++ b/example.json
@@ -10,7 +10,7 @@
       "body": "This is optional body text. Select the hotspots on the image to reveal the text. This component will scale down to a narrative when viewed on mobile.",
       "mobileBody": "This is optional body text that will be shown when viewed on mobile.",
       "instruction":"",
-      "_pinNarrative": true, // if true it will use the pins as graphics instead of the large graphic
+      "_useGraphicsAsPins": false, 
       "_graphic": {
         "src": "hot_graphic.jpg",
         "alt": "alt text",
@@ -24,10 +24,10 @@
                 "src": "image1.jpg",
                 "alt": "alt text",
                 "title": "title text",
-                "_classes": "cols-2 rows-1" // Image will be 2 blocks wide, 1 block high
+                "_classes": "cols-2 rows-1" 
             },
             "strapline": "strapline...",
-            "_classes": "top-left", // Position to display the popup
+            "_classes": "top-left", 
             "_top": 5,
             "_left": 20
         },
@@ -38,7 +38,7 @@
                 "src": "image2.jpg",
                 "alt": "alt text",
                 "title": "title text",
-                "_classes": "cols-2 rows-1" // Image will be 2 blocks wide, 1 block high
+                "_classes": "cols-2 rows-1"
             },
             "strapline": "strapline...",
             "_classes": "center",
@@ -52,7 +52,7 @@
                 "src": "image3.jpg",
                 "alt": "alt text",
                 "title": "title text",
-                "_classes": "cols-1 rows-1" // Image will be 2 blocks wide, 1 block high
+                "_classes": "cols-1 rows-1" 
             },
             "strapline": "strapline...",
             "_classes": "bottom-right",

--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -78,7 +78,10 @@ define(function(require) {
         this.$('.hotgraphic-popup-nav').addClass('last');
       }
 
-      var classes = this.model.get("_items")[index]._classes;
+      var classes = this.model.get("_items")[index]._classes 
+        ? this.model.get("_items")[index]._classes
+        : '';  // _classes has not been defined
+        
       this.$('.hotgraphic-popup').attr('class', 'hotgraphic-popup ' + 'item-' + index + ' ' + classes);
     },
 

--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -78,7 +78,8 @@ define(function(require) {
         this.$('.hotgraphic-popup-nav').addClass('last');
       }
 
-      this.$('.hotgraphic-popup').attr('class', 'hotgraphic-popup ' + 'item-' + index);
+      var classes = this.model.get("_items")[index]._classes;
+      this.$('.hotgraphic-popup').attr('class', 'hotgraphic-popup ' + 'item-' + index + ' ' + classes);
     },
 
     openHotGraphic: function (event) {
@@ -90,7 +91,6 @@ define(function(require) {
       this.setVisited(currentIndex);
       this.$('.hotgraphic-popup-count .current').html(currentIndex+1);
       this.$('.hotgraphic-popup-count .total').html(this.$('.hotgraphic-item').length);
-      this.$('.hotgraphic-popup').attr('class', 'hotgraphic-popup ' + 'item-' + currentIndex);
       this.$('.hotgraphic-popup').show();
       this.$('.hotgraphic-popup a.next').focus();
       this.applyNavigationClasses(currentIndex);

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -111,6 +111,77 @@
 
 }
 
+// Hotgraphic Narrative
+
+.hotgraphic-narrative {
+  .hotgraphic-graphic-pin {
+    border-radius: 0px;
+    position:absolute;
+    display:block;
+    box-sizing:border-box;
+    -moz-box-sizing:border-box;
+    -webkit-box-sizing:border-box;
+    border:4px solid @background-color;
+    background-size: cover;
+    transition: background-size .4s;
+    overflow:hidden;
+    .hotgraphic-graphic-pin-image {
+        display:block;
+        position:absolute;
+        width:100%;
+        height:100%;
+        -webkit-transition: transform .4s;
+        transition: transform .4s;
+        background-size: cover;
+        &:before {
+            content: '';
+            position:absolute;
+            top:0px;
+            left:0px;
+            width:100%;
+            height:100%;
+            background:fadeout(@foreground-color, 50%);
+            transition: background .5s;
+        }
+    }
+    &:hover {
+        .hotgraphic-graphic-pin-image {
+            -webkit-transform: scale(1.1);
+            transform: scale(1.1);
+            &:before {
+                background:fadeout(@foreground-color, 100%);
+            }
+        }
+    }
+  }
+}
+
+// Narrative Pin Size & Position
+
+.cols-1 {
+  width: 25%;
+}
+
+.cols-2 {
+  width: 50%;
+}
+
+.cols-3 {
+  width: 75%;
+}
+
+.cols-4 {
+  width: 100%;
+}
+
+.rows-1 {
+  height: 50%;
+}
+
+.rows-2 {
+  height: 100%;
+}
+
 .no-touch {
   .hotgraphic-component {
     .hotgraphic-graphic-pin-icon {
@@ -134,5 +205,4 @@
       }
     }
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A contributed hot graphic component that enables a user to click on hot spots over an image and display a detailed popup that includes an image with text.",
   "main": "",
   "scripts": {

--- a/properties.schema
+++ b/properties.schema
@@ -52,6 +52,15 @@
       "validators": [],
       "help": "If set to 'true', the progress indicator and previous and next links will not be shown on the popup toolbar"
     },
+    "_useGraphicsAsPins": {
+      "type":"boolean",
+      "required":true,
+      "default": false,
+      "title": "Use graphics as pins",
+      "inputType": {"type": "Boolean", "options": [true, false]},
+      "validators": [],
+      "help": "If set to 'true', the main graphic will be hidden and pins will be displayed as images which can be positioned using classes"
+    },
     "_items": {
       "type":"array",
       "required":true,

--- a/properties.schema
+++ b/properties.schema
@@ -104,8 +104,34 @@
                 "inputType": "Text",
                 "validators": [],
                 "help": "Alternative text for this image"
+              },
+              "title": {
+                "type":"string",
+                "required":true,
+                "default": "",
+                "inputType": "Text",
+                "validators": [],
+                "help": "Title text for this image"
+              },
+              "classes": {
+                "type":"string",
+                "required": false,
+                "default": "",
+                "title": "Classes",
+                "inputType": "Text",
+                "validators": [],
+                "help": ""
               }
             }
+          },
+          "classes": {
+            "type":"string",
+            "required": false,
+            "default": "",
+            "title": "Classes",
+            "inputType": "Text",
+            "validators": [],
+            "help": ""
           },
           "_left": {
             "type":"number",

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -52,10 +52,10 @@
 
       </div>
 
-      {{#if _pinNarrative}}
+      {{#if _useGraphicsAsPins}}
         <div class="hotgraphic-narrative">
           {{#each _items}}
-          <a href="#" class="hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{_graphic._classes}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" title="{{graphicTitle}}">
+          <a href="#" class="hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" title="{{_graphic.title}}">
             <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
           </a>
           {{/each}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -28,7 +28,7 @@
 
         <div class="hotgraphic-popup-inner clearfix">
           {{#each _items}}
-          <div class="hotgraphic-item component-item item-{{@index}}">
+          <div class="hotgraphic-item component-item item-{{@index}} {{_classes}}">
             <div class="hotgraphic-item-graphic">
               <div class="hotgraphic-item-graphic-inner">
                 <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" title="{{{_graphic.title}}}"/>
@@ -50,12 +50,22 @@
 
       </div>
 
-      <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" title="{{{_graphic.title}}}"/>
-      {{#each _items}}
-      <a href="#" class="hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" title="{{graphicTitle}}">
-        <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
-      </a>
-      {{/each}}
+      {{#if _pinNarrative}}
+        <div class="hotgraphic-narrative">
+          {{#each _items}}
+          <a href="#" class="hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{_graphic._classes}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" title="{{graphicTitle}}">
+            <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
+          </a>
+          {{/each}}
+        </div>
+      {{else}}
+        <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" title="{{{_graphic.title}}}"/>
+        {{#each _items}}
+        <a href="#" class="hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" title="{{graphicTitle}}">
+          <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+        </a>
+        {{/each}}
+      {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Some tweaks to the Hot Graphic to allow using custom graphics as pins via the `_useGraphicsAsPins` property.  Existing functionality is left as is.