### PR TITLE
Removed circular dependency on narrative

### DIFF
--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -68,7 +68,9 @@ define(function(require) {
         },
 
         replaceWithNarrative: function() {
-            var Narrative = require('components/adapt-contrib-narrative/js/adapt-contrib-narrative');
+            if (!Adapt.componentStore.narrative) throw "Narrative not included in build";
+            var Narrative = Adapt.componentStore.narrative;
+
             var model = this.prepareNarrativeModel();
             var newNarrative = new Narrative({model: model, $parent: this.options.$parent});
             newNarrative.reRender();


### PR DESCRIPTION
Issues occur in ie8 whereby neither components are loaded on first load from LMS