### PR TITLE
Fix for mobile component switch

### DIFF
--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -89,10 +89,11 @@ define(function(require) {
 
             var model = this.prepareNarrativeModel();
             var newNarrative = new Narrative({ model: model });
+            var $container = $(".component-container", $("." + this.model.get("_parentId")));
 
             newNarrative.reRender();
             newNarrative.setupNarrative();
-            $("." + this.model.get("_parentId") + ' .component-container').append(newNarrative.$el);
+            $container.append(newNarrative.$el);
             Adapt.trigger('device:resize');
             this.remove();
         },

--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -92,7 +92,7 @@ define(function(require) {
 
             newNarrative.reRender();
             newNarrative.setupNarrative();
-            $("." + this.model.get("_parentId")).append(newNarrative.$el);
+            $("." + this.model.get("_parentId") + ' .component-container').append(newNarrative.$el);
             Adapt.trigger('device:resize');
             this.remove();
         },


### PR DESCRIPTION
Fix for when the hotgraphic switches to a narrative component for mobile view. Component now gets appended to the 'component-container' div rather than outside of it.