### PR TITLE
Fix for display issue in Chrome

### DIFF
--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -104,6 +104,10 @@
         margin-left: @item-padding-right;
     }
     vertical-align: baseline;
+
+    span {
+      display: inline-block;
+    }
   }
 
   .hotgraphic-popup-controls {


### PR DESCRIPTION
If body text has markup this can cause rendering bugs in Chrome within the popup, such as; the counter missing characters or body text from other hotspots overlapping.