### PR TITLE
css fix for hotgraphic pin overlay offset issue

### DIFF
--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -2,6 +2,7 @@
 
 	.hotgraphic-graphic {
 		position: relative;
+		display:inline-block;
 	}
 
 	.hotgraphic-graphic-pin {


### PR DESCRIPTION
Added `display:inline-block` to hotgraphic.less file which fixes pin overlay offset.