### PR TITLE
remove _isComplete condition on setCompletionStatus

### DIFF
--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -231,10 +231,8 @@ define(function(require) {
         },
 
         checkCompletionStatus: function() {
-            if (!this.model.get('_isComplete')) {
-                if (this.getVisitedItems().length == this.model.get('_items').length) {
-                    this.trigger('allItems');
-                }
+            if (this.getVisitedItems().length == this.model.get('_items').length) {
+                this.trigger('allItems');
             }
         },
 


### PR DESCRIPTION
On revisit in LMS _isComplete is true but _isInteractionComplete is
false. Prevents _isInteractionComplete being set to true and trickle
etc from working.