### PR TITLE
fix for layout breaking when using 'graphics as pins'

### DIFF
--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -2,6 +2,7 @@
 
 	.hotgraphic-graphic {
 		position: relative;
+		width: 100%;
 	}
 
 	.hotgraphic-graphic-pin {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -160,7 +160,6 @@
 		overflow:hidden;
 		.hotgraphic-graphic-pin-image {
 			display:block;
-			position:absolute;
 			width:100%;
 			height:100%;
 			-webkit-transition: transform .4s;


### PR DESCRIPTION
added width:100% which fixes the layout when using graphics as pins