### PR TITLE
Reverting default text string on strapline property for consistency

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -136,7 +136,7 @@
           "strapline": {
             "type":"string",
             "required":true,
-            "default": "Tap on '+' for more info",
+            "default": "",
             "inputType": "Text",
             "validators": ["required"],
             "help": "Strapline displayed on mobile version",


### PR DESCRIPTION
In the interest of consistency, I've reverted the strapline string default back to the way it was. 