### PR TITLE
Issue 1401 Hotgraphic component validation

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -45,10 +45,10 @@
       "properties":{
         "src": {
           "type":"string",
-          "required":true,
+          "required":false,
           "default": "",
           "inputType": "Asset:image",
-          "validators": ["required"],
+          "validators": [],
           "help": "This is the image that appears behind the pins"
         },
         "alt": {


### PR DESCRIPTION
Setting required to false on `_graphic.src` which fixes form validation issue when `_useGraphicsAsPins` is set to true.

Previously when `_useGraphicsAsPins = true` it wasn't possible to save the form without the Main Hotgraphic image `src` property being set

https://github.com/adaptlearning/adapt_framework/issues/1401