### PR TITLE
Numbers instead of icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ guide the learner’s interaction with the component.
 
 **_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.  
 
+**_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
+
+**_useNumbersAsPins** (boolean): When set to `true`, Changes the pins to with incrementing numbers. The default is `false`.
+
 **_graphic** (string): The main image that appears below the hot spots. It contains values for **src**, **alt** and **title**.
 
 >**src** (string): File name (including path) of the image. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-two.jpg*).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ guide the learner’s interaction with the component.
 
 **_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
 
-**_useNumbersAsPins** (boolean): When set to `true`, Changes the pins to with incrementing numbers. The default is `false`.
+**_useNumbersAsPins** (boolean): When set to `true`, replaces the pins with incrementing numbers. The default is `false`.
 
 **_graphic** (string): The main image that appears below the hot spots. It contains values for **src**, **alt** and **title**.
 
@@ -94,8 +94,8 @@ When viewport size changes to the smallest range, this component will behave lik
 
 
 ----------------------------
-**Version number:**  2.0.8   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:**  2.0     
+**Version number:**  2.0.9   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
+**Framework versions:**  2.0.11
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-hotgraphic/graphs/contributors)  
 **Accessibility support:** WAI AA   
 **RTL support:** yes  

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "2.0.8",
-  "framework": "^2.0.0",
+  "version": "2.0.9",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-hotgraphic%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "description": "A contributed hot graphic component that enables a user to click on hot spots over an image and display a detailed popup that includes an image with text.",

--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
     "_useGraphicsAsPins": false,
+    "_useNumbersAsPins": false,
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {
@@ -89,6 +90,7 @@
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
     "_useGraphicsAsPins": true,
+    "_useNumbersAsPins": false,
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -150,11 +150,11 @@
 					width: 40px;
 					height: 40px;
 					background-color: @item-color;
-					&:hover {
-							background-color: @item-color-hover;
-						}
 					&.visited {
 						background-color: @item-color-visited;
+					}
+					&:hover {
+							background-color: @item-color-hover;
 					}
 				}
 				.hotgraphic-graphic-number-icon {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -143,6 +143,29 @@
         font-size:0.75em;
         line-height: 1em;
     }
+
+		.hotgraphic-widget {
+			&.numbers {
+				.hotgraphic-graphic-pin {
+					padding: 15px;
+					border-radius: 100%;
+					background-color: @item-color;
+					&:hover {
+							background-color: @item-color-hover;
+						}
+					&.visited {
+						background-color: @item-color-visited;
+					}
+					&.visited {
+						background-color: @item-color-visited;
+					}
+				}
+				.hotgraphic-graphic-number-icon {
+					font-size: @icon-size;
+					color: @item-text-color;
+				}
+			}
+		}
 }
 
 // Hotgraphic Narrative

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -123,7 +123,7 @@
 		text-align: center;
 	}
 
-	.hotgraphic-item-graphic-inner{
+	.hotgraphic-item-graphic-inner {
 		padding-left: @item-padding-left;
 		.dir-rtl & {
 			padding-left: inherit;
@@ -153,9 +153,6 @@
 					&:hover {
 							background-color: @item-color-hover;
 						}
-					&.visited {
-						background-color: @item-color-visited;
-					}
 					&.visited {
 						background-color: @item-color-visited;
 					}

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -147,8 +147,8 @@
 		.hotgraphic-widget {
 			&.numbers {
 				.hotgraphic-graphic-pin {
-					padding: 15px;
-					border-radius: 100%;
+					width: 40px;
+					height: 40px;
 					background-color: @item-color;
 					&:hover {
 							background-color: @item-color-hover;
@@ -158,7 +158,8 @@
 					}
 				}
 				.hotgraphic-graphic-number-icon {
-					font-size: @icon-size;
+					font-size: 20px;
+					text-align: center;
 					color: @item-text-color;
 				}
 			}

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -144,7 +144,7 @@
         line-height: 1em;
     }
 
-	.hotgraphic-widget .numbers {
+	.numbers {
 		.hotgraphic-graphic-pin {
 			width: 40px;
 			height: 40px;
@@ -153,7 +153,7 @@
 				background-color: @item-color-visited;
 			}
 			.no-touch &:hover {
-					background-color: @item-color-hover;
+				background-color: @item-color-hover;
 			}
 		}
 		.hotgraphic-graphic-number-icon {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -144,26 +144,24 @@
         line-height: 1em;
     }
 
-		.hotgraphic-widget {
-			&.numbers {
-				.hotgraphic-graphic-pin {
-					width: 40px;
-					height: 40px;
-					background-color: @item-color;
-					&.visited {
-						background-color: @item-color-visited;
-					}
-					&:hover {
-							background-color: @item-color-hover;
-					}
-				}
-				.hotgraphic-graphic-number-icon {
-					font-size: 20px;
-					text-align: center;
-					color: @item-text-color;
-				}
+	.hotgraphic-widget .numbers {
+		.hotgraphic-graphic-pin {
+			width: 40px;
+			height: 40px;
+			background-color: @item-color;
+			&.visited {
+				background-color: @item-color-visited;
+			}
+			.no-touch &:hover {
+					background-color: @item-color-hover;
 			}
 		}
+		.hotgraphic-graphic-number-icon {
+			font-size: 20px;
+			text-align: center;
+			color: @item-text-color;
+		}
+	}
 }
 
 // Hotgraphic Narrative

--- a/properties.schema
+++ b/properties.schema
@@ -116,6 +116,15 @@
       "validators": [],
       "help": "If set to 'true', the main graphic will be hidden and pins will be displayed as images which can be positioned using classes"
     },
+    "_useNumbersAsPins": {
+      "type":"boolean",
+      "required":true,
+      "default": false,
+      "title": "Use numbers as pins",
+      "inputType": {"type": "Boolean", "options": [false, true]},
+      "validators": [],
+      "help": "If set to 'true', pins will be replaced by numbers. Don't use with <strong>Use graphics as pins</strong>"
+    },
     "_items": {
       "type":"array",
       "required":true,

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{inc @index}}">{{inc @index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{inc @index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{math @index "+" 1}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{@index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{math @index "+" 1}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else}}pin{{/if}}">
+  <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else if  _useNumbersAsPins}}numbers{{else}}pin{{/if}}">
 
     <div class="hotgraphic-graphic">
 
@@ -66,7 +66,11 @@
         {{/if}}
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+            {{#if ../_useNumbersAsPins}}
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{@index}}</div>
+            {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+            {{/if}}
           </button>
         {{/each}}
       {{/if}}


### PR DESCRIPTION
See https://github.com/adaptlearning/adapt_framework/issues/1570

This PR adds numbers as an option instead of using the standard pin icons. It uses `{{inc @index}}` in handlebars to populate the button.

Would appreciate a look over from a front-end developer to have another opinion on the size of buttons and the text.

