### PR TITLE
_pinStyle and _iconClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ guide the learner’s interaction with the component.
 
 **_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.  
 
+**_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
+
+**_useNumbersAsPins** (boolean): When set to `true`, Changes the pins to with incrementing numbers. The default is `false`.
+
 **_graphic** (string): The main image that appears below the hot spots. It contains values for **src**, **alt** and **title**.
 
 >**src** (string): File name (including path) of the image. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-two.jpg*).

--- a/README.md
+++ b/README.md
@@ -50,11 +50,7 @@ guide the learner’s interaction with the component.
 
 **_pinStyle** (string): This optional attribute changes the styling of the pin. `default` sets these pins to be icons. `numbers` replaces the pins with incrementing numbers. `tiles` replaces the pins with larger images which can be positioned using classes. Any other attribute or this attribute not being presented results in `default` being used.
 
-**_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.  
-
-**_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
-
-**_useNumbersAsPins** (boolean): When set to `true`, replaces the pins with incrementing numbers. The default is `false`.
+**_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.
 
 **_graphic** (string): The main image that appears below the hot spots. It contains values for **src**, **alt** and **title**.
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ guide the learner’s interaction with the component.
 **mobileInstruction** (string): This is optional text that will be substituted for **instruction** when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices).  
 
 **_setCompletionOn** (string): This value determines when the component registers as complete. Acceptable values are `"allItems"` and `"inview"`. `"allItems"` requires each pop-up item to be visited. `"inview"` requires the **Hot Graphic** component to enter the view port completely.  
-  
+
 **_canCycleThroughPagination** (boolean): Enables the pop-ups to be cycled through endlessly using either the previous or next icon. When set to `true`, clicking "next" on the final stage will display the very first stage. When set to `false`, the final stage will display only a "previous" icon. The default is `false`.  
 
-**_pinStyle** (string): This optional attribute changes the styling of the pin. `default` sets these pins to be icons. `numbers` replaces the pins with incrementing numbers. `tile` replaces the pins with larger images which can be positioned using classes. Any other attribute or this attribute not being presented results in `default` being used.
+**_pinStyle** (string): This optional attribute changes the styling of the pin. `default` sets these pins to be icons. `numbers` replaces the pins with incrementing numbers. `tiles` replaces the pins with larger images which can be positioned using classes. Any other attribute or this attribute not being presented results in `default` being used.
 
 **_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.  
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ guide the learner’s interaction with the component.
   
 **_canCycleThroughPagination** (boolean): Enables the pop-ups to be cycled through endlessly using either the previous or next icon. When set to `true`, clicking "next" on the final stage will display the very first stage. When set to `false`, the final stage will display only a "previous" icon. The default is `false`.  
 
+**_pinStyle** (string): This optional attribute changes the styling of the pin. `default` sets these pins to be icons. `numbers` replaces the pins with incrementing numbers. `tile` replaces the pins with larger images which can be positioned using classes. Any other attribute or this attribute not being presented results in `default` being used.
+
 **_hidePagination** (boolean): When set to `true`, hides the "previous" and "next" icons and progress indicator (e.g., "1/5") on the pop-up's toolbar. The default is `false`.  
 
 **_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
@@ -77,6 +79,8 @@ guide the learner’s interaction with the component.
 >>**alt** (string): This text becomes the image’s `alt` attribute.   
 
 >>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
+
+>**_iconClass** (string): Overrides the default pin icon with a custom icon with the name.
 
 >**strapline** (string): This text is displayed when `Adapt.device.screenSize` is `small` (i.e., when viewed on mobile devices). It is presented in a title bar above the image.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ guide the learner’s interaction with the component.
 
 **_useGraphicsAsPins** (boolean): When set to `true`, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes. The default is `false`.
 
-**_useNumbersAsPins** (boolean): When set to `true`, Changes the pins to with incrementing numbers. The default is `false`.
+**_useNumbersAsPins** (boolean): When set to `true`, replaces the pins with incrementing numbers. The default is `false`.
 
 **_graphic** (string): The main image that appears below the hot spots. It contains values for **src**, **alt** and **title**.
 
@@ -94,8 +94,8 @@ When viewport size changes to the smallest range, this component will behave lik
 
 
 ----------------------------
-**Version number:**  2.0.8   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:**  2.0     
+**Version number:**  2.0.9   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
+**Framework versions:**  2.0.11
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-hotgraphic/graphs/contributors)  
 **Accessibility support:** WAI AA   
 **RTL support:** yes  

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "2.0.8",
-  "framework": "^2.0.0",
+  "version": "2.0.9",
+  "framework": "^2.0.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-hotgraphic%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "description": "A contributed hot graphic component that enables a user to click on hot spots over an image and display a detailed popup that includes an image with text.",

--- a/example.json
+++ b/example.json
@@ -14,7 +14,7 @@
     "instruction":"",
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
-    "_pinStyle": "default" // default | numbers | tile
+    "_pinStyle": "default", // default | numbers | tiles
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {
@@ -32,7 +32,7 @@
                 "attribution":"Copyright © 2015",
                 "_classes": ""
             },
-            "_iconClass": "star",
+            "_iconClass": "icon-star",
             "pinAlt": "alt text",
             "strapline": "strapline...",
             "_classes": "top-left",
@@ -60,7 +60,7 @@
             "_graphic": {
                 "src": "image3.jpg",
                 "alt": "alt text",
-                "attribution":"Copyright © 2015",
+                "attribution": "Copyright © 2015",
                 "_classes": ""
             },
             "pinAlt": "alt text",
@@ -89,8 +89,7 @@
     "instruction":"",
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
-    "_useGraphicsAsPins": true,
-    "_useNumbersAsPins": false,
+    "_pinStyle": "tiles", // default | numbers | tiles
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {
@@ -161,4 +160,3 @@
         }
     ]
 }
-

--- a/example.json
+++ b/example.json
@@ -1,4 +1,4 @@
-// Regular hotgraphic
+// Example for _pinStyle default and numbers.
 
 {
     "_id": "c-40",
@@ -6,7 +6,7 @@
     "_classes": "",
     "_type":"component",
     "_component": "hotgraphic",
-    "_layout": "full",    
+    "_layout": "full",
     "title": "Hot graphic",
     "displayTitle": "Hot graphic",
     "body": "This is optional body text. Select the hotspots on the image to reveal the text. This component will scale down to a narrative when viewed on mobile.",
@@ -72,8 +72,8 @@
     ]
 }
 
-// Example using graphics as pins
-// The following example lays out the item graphics (_items._graphic) in a 2x2 grid. 
+// Example for _pinStyle tiles.
+// The following example lays out the item graphics (_items._graphic) in a 2x2 grid.
 
 {
     "_id": "c-40",
@@ -81,7 +81,7 @@
     "_classes": "",
     "_type":"component",
     "_component": "hotgraphic",
-    "_layout": "full",    
+    "_layout": "full",
     "title": "Hot graphic",
     "displayTitle": "Hot graphic",
     "body": "This is optional body text. Select the hotspots on the image to reveal the text. This component will scale down to a narrative when viewed on mobile.",

--- a/example.json
+++ b/example.json
@@ -14,7 +14,7 @@
     "instruction":"",
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
-    "_pinStyle": "default" // default | numbers | graphic
+    "_pinStyle": "default" // default | numbers | tile
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {

--- a/example.json
+++ b/example.json
@@ -14,8 +14,7 @@
     "instruction":"",
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
-    "_useGraphicsAsPins": false,
-    "_useNumbersAsPins": false,
+    "_pinStyle": "default" // default | numbers | graphic
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {
@@ -33,6 +32,7 @@
                 "attribution":"Copyright © 2015",
                 "_classes": ""
             },
+            "_iconClass": "star",
             "pinAlt": "alt text",
             "strapline": "strapline...",
             "_classes": "top-left",

--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
     "_useGraphicsAsPins": false,
+    "_useNumbersAsPins": false,
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {
@@ -89,6 +90,7 @@
     "mobileInstruction": "This is optional instruction text that will be shown when viewed on mobile.",
     "_setCompletionOn":"allItems",
     "_useGraphicsAsPins": true,
+    "_useNumbersAsPins": false,
     "_canCycleThroughPagination": false,
     "_hidePagination": false,
     "_graphic": {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -150,11 +150,11 @@
 					width: 40px;
 					height: 40px;
 					background-color: @item-color;
-					&:hover {
-							background-color: @item-color-hover;
-						}
 					&.visited {
 						background-color: @item-color-visited;
+					}
+					&:hover {
+							background-color: @item-color-hover;
 					}
 				}
 				.hotgraphic-graphic-number-icon {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -36,7 +36,7 @@
 			}
 
 			.hotgraphic-graphic-number-icon {
-				font-size: 20px;
+				font-size: 24px;
 				text-align: center;
 				color: @item-text-color;
 			}

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -143,6 +143,29 @@
         font-size:0.75em;
         line-height: 1em;
     }
+
+		.hotgraphic-widget {
+			&.numbers {
+				.hotgraphic-graphic-pin {
+					padding: 15px;
+					border-radius: 100%;
+					background-color: @item-color;
+					&:hover {
+							background-color: @item-color-hover;
+						}
+					&.visited {
+						background-color: @item-color-visited;
+					}
+					&.visited {
+						background-color: @item-color-visited;
+					}
+				}
+				.hotgraphic-graphic-number-icon {
+					font-size: @icon-size;
+					color: @item-text-color;
+				}
+			}
+		}
 }
 
 // Hotgraphic Narrative

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -123,7 +123,7 @@
 		text-align: center;
 	}
 
-	.hotgraphic-item-graphic-inner{
+	.hotgraphic-item-graphic-inner {
 		padding-left: @item-padding-left;
 		.dir-rtl & {
 			padding-left: inherit;
@@ -153,9 +153,6 @@
 					&:hover {
 							background-color: @item-color-hover;
 						}
-					&.visited {
-						background-color: @item-color-visited;
-					}
 					&.visited {
 						background-color: @item-color-visited;
 					}

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -24,6 +24,23 @@
 				color: @item-color-hover;
 			}
 		}
+		&.number {
+			width: 48px;
+			height: 48px;
+			background-color: @item-color;
+			&.visited {
+				background-color: @item-color-visited;
+			}
+			.no-touch &:hover {
+				background-color: @item-color-hover;
+			}
+
+			.hotgraphic-graphic-number-icon {
+				font-size: 20px;
+				text-align: center;
+				color: @item-text-color;
+			}
+		}
 	}
 
 	.hotgraphic-graphic-pin-icon {
@@ -143,25 +160,6 @@
         font-size:0.75em;
         line-height: 1em;
     }
-
-	.numbers {
-		.hotgraphic-graphic-pin {
-			width: 40px;
-			height: 40px;
-			background-color: @item-color;
-			&.visited {
-				background-color: @item-color-visited;
-			}
-			.no-touch &:hover {
-				background-color: @item-color-hover;
-			}
-		}
-		.hotgraphic-graphic-number-icon {
-			font-size: 20px;
-			text-align: center;
-			color: @item-text-color;
-		}
-	}
 }
 
 // Hotgraphic Narrative

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -147,8 +147,8 @@
 		.hotgraphic-widget {
 			&.numbers {
 				.hotgraphic-graphic-pin {
-					padding: 15px;
-					border-radius: 100%;
+					width: 40px;
+					height: 40px;
 					background-color: @item-color;
 					&:hover {
 							background-color: @item-color-hover;
@@ -158,7 +158,8 @@
 					}
 				}
 				.hotgraphic-graphic-number-icon {
-					font-size: @icon-size;
+					font-size: 20px;
+					text-align: center;
 					color: @item-text-color;
 				}
 			}

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -144,7 +144,7 @@
         line-height: 1em;
     }
 
-	.hotgraphic-widget .numbers {
+	.numbers {
 		.hotgraphic-graphic-pin {
 			width: 40px;
 			height: 40px;
@@ -153,7 +153,7 @@
 				background-color: @item-color-visited;
 			}
 			.no-touch &:hover {
-					background-color: @item-color-hover;
+				background-color: @item-color-hover;
 			}
 		}
 		.hotgraphic-graphic-number-icon {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -144,26 +144,24 @@
         line-height: 1em;
     }
 
-		.hotgraphic-widget {
-			&.numbers {
-				.hotgraphic-graphic-pin {
-					width: 40px;
-					height: 40px;
-					background-color: @item-color;
-					&.visited {
-						background-color: @item-color-visited;
-					}
-					&:hover {
-							background-color: @item-color-hover;
-					}
-				}
-				.hotgraphic-graphic-number-icon {
-					font-size: 20px;
-					text-align: center;
-					color: @item-text-color;
-				}
+	.hotgraphic-widget .numbers {
+		.hotgraphic-graphic-pin {
+			width: 40px;
+			height: 40px;
+			background-color: @item-color;
+			&.visited {
+				background-color: @item-color-visited;
+			}
+			.no-touch &:hover {
+					background-color: @item-color-hover;
 			}
 		}
+		.hotgraphic-graphic-number-icon {
+			font-size: 20px;
+			text-align: center;
+			color: @item-text-color;
+		}
+	}
 }
 
 // Hotgraphic Narrative

--- a/properties.schema
+++ b/properties.schema
@@ -115,7 +115,7 @@
       "title": "Pin Style",
       "help": "Default uses pins. Numbers uses ascending numbers. Tiles replaces the pin with larger images. Default and numbers can be overriden with custom icons using icon class.",
       "inputType": {"type": "Select", "options":["default", "numbers", "tiles"]},
-      "validators": [],
+      "validators": []
     },
     "_items": {
       "type":"array",

--- a/properties.schema
+++ b/properties.schema
@@ -68,7 +68,7 @@
           "validators": [],
           "help": "Text to be displayed as an attribution",
           "translatable": true
-        }        
+        }
       }
     },
     "mobileBody": {
@@ -108,31 +108,14 @@
       "help": "If set to 'true', the items in the open popup will be allowed to cycle through continiously"
     },
     "_pinStyle": {
-      "type":"text",
-      "required":true,
+      "type":"string",
+      "required": false,
+      "enum": ["default", "numbers", "tiles"],
       "default": "default",
       "title": "Pin Style",
-      "inputType": {"type": "String", "options": ["default", "numbers", "tiles"]},
+      "help": "Default uses pins. Numbers uses ascending numbers. Tiles replaces the pin with larger images. Default and numbers can be overriden with custom icons using icon class.",
+      "inputType": {"type": "Select", "options":["default", "numbers", "tiles"]},
       "validators": [],
-      "help": "Default uses pins. Numbers uses ascending numbers. Tiles replaces the pin with larger images. Default and numbers can be overriden with custom icons using icon class."
-    },
-    "_useGraphicsAsPins": {
-      "type":"boolean",
-      "required":true,
-      "default": false,
-      "title": "Use graphics as pins",
-      "inputType": {"type": "Boolean", "options": [false, true]},
-      "validators": [],
-      "help": "If set to 'true', the main graphic will be hidden and pins will be displayed as images which can be positioned using classes"
-    },
-    "_useNumbersAsPins": {
-      "type":"boolean",
-      "required":true,
-      "default": false,
-      "title": "Use numbers as pins",
-      "inputType": {"type": "Boolean", "options": [false, true]},
-      "validators": [],
-      "help": "If set to 'true', pins will be replaced by numbers. Don't use with <strong>Use graphics as pins</strong>"
     },
     "_items": {
       "type":"array",
@@ -224,10 +207,10 @@
             "type":"string",
             "required":false,
             "default": "",
-            "inputType": "Icon class",
+            "inputType": "Text",
+            "title": "Icon class",
             "validators": [],
-            "help": "Override the default icon to use a custom icon. List of support icons <a href='https://github.com/adaptlearning/adapt-contrib-vanilla/blob/19f050f9fb271fb10525ed8b71211ff2569e5747/less/src/icons.less#L36-L362'>here</a>.",
-            "translatable": true
+            "help": "Override the default icon to use a custom icon. Works with default and numbers."
           },
           "_classes": {
             "type":"string",

--- a/properties.schema
+++ b/properties.schema
@@ -116,6 +116,15 @@
       "validators": [],
       "help": "If set to 'true', the main graphic will be hidden and pins will be displayed as images which can be positioned using classes"
     },
+    "_useNumbersAsPins": {
+      "type":"boolean",
+      "required":true,
+      "default": false,
+      "title": "Use numbers as pins",
+      "inputType": {"type": "Boolean", "options": [false, true]},
+      "validators": [],
+      "help": "If set to 'true', pins will be replaced by numbers. Don't use with <strong>Use graphics as pins</strong>"
+    },
     "_items": {
       "type":"array",
       "required":true,

--- a/properties.schema
+++ b/properties.schema
@@ -107,6 +107,15 @@
       "validators": [],
       "help": "If set to 'true', the items in the open popup will be allowed to cycle through continiously"
     },
+    "_pinStyle": {
+      "type":"text",
+      "required":true,
+      "default": "default",
+      "title": "Pin Style",
+      "inputType": {"type": "String", "options": ["default", "numbers", "tiles"]},
+      "validators": [],
+      "help": "Default uses pins. Numbers uses ascending numbers. Tiles replaces the pin with larger images. Default and numbers can be overriden with custom icons using icon class."
+    },
     "_useGraphicsAsPins": {
       "type":"boolean",
       "required":true,
@@ -210,6 +219,15 @@
                 "help": ""
               }
             }
+          },
+          "_iconClass": {
+            "type":"string",
+            "required":false,
+            "default": "",
+            "inputType": "Icon class",
+            "validators": [],
+            "help": "Override the default icon to use a custom icon. List of support icons <a href='https://github.com/adaptlearning/adapt-contrib-vanilla/blob/19f050f9fb271fb10525ed8b71211ff2569e5747/less/src/icons.less#L36-L362'>here</a>.",
+            "translatable": true
           },
           "_classes": {
             "type":"string",

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{inc @index}}">{{inc @index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{inc @index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tiles' }}tile{{else}}{{#if _useGraphicsAsPins}}tile{{else}}pins{{/if}}{{/compare}}">
+  <div class="hotgraphic-widget component-widget {{#equals _pinStyle 'tiles' }}tile{{else}}{{#if _useGraphicsAsPins}}tile{{else}}pins{{/if}}{{/equals}}">
 
     <div class="hotgraphic-graphic">
 
@@ -51,7 +51,7 @@
           {{/each}}
         </div>
       </div>
-      {{#compare _pinStyle '=' 'tiles' }}
+      {{#equals _pinStyle 'tiles'}}
         <div class="hotgraphic-narrative">
           {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
@@ -74,16 +74,16 @@
           <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
         {{/if}}
         {{#each _items}}
-          <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}} {{#compare ../_pinStyle '=' 'numbers' }}{{#unless _iconClass}}number{{/unless}}{{/compare}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
-            {{#compare ../_pinStyle '=' 'numbers' }}
+          <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}} {{#equals ../_pinStyle 'numbers'}}{{#unless _iconClass}}number{{/unless}}{{/equals}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+            {{#equals ../_pinStyle 'numbers'}}
             <div class="{{#if _iconClass}}hotgraphic-graphic-pin-icon icon {{_iconClass}}{{else}}hotgraphic-graphic-number-icon{{/if}} component-item-color item-{{@index}}">{{#unless _iconClass}}{{inc @index}}{{/unless}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon {{#if _iconClass}}{{_iconClass}}{{else}}icon-pin{{/if}} item-{{@index}}"></div>
-            {{/compare}}
+            {{/equals}}
           </button>
         {{/each}}
       {{/if}}
-      {{/compare}}
+      {{/equals}}
     </div>
   </div>
 </div>

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{math @index "+" 1}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{else}}{{#if _useGraphicsAsPins}}tile{{else}}pins{{/if}}{{/compare}}">
+  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tiles' }}tile{{else}}{{#if _useGraphicsAsPins}}tile{{else}}pins{{/if}}{{/compare}}">
 
     <div class="hotgraphic-graphic">
 
@@ -51,7 +51,16 @@
           {{/each}}
         </div>
       </div>
-      {{#compare _pinStyle '=' 'tile' }}
+      {{#compare _pinStyle '=' 'tiles' }}
+        <div class="hotgraphic-narrative">
+          {{#each _items}}
+          <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+            <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
+          </button>
+          {{/each}}
+        </div>
+      {{else}}
+      {{#if _useGraphicsAsPins}}
         <div class="hotgraphic-narrative">
           {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
@@ -73,6 +82,7 @@
             {{/compare}}
           </button>
         {{/each}}
+      {{/if}}
       {{/compare}}
     </div>
   </div>

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else if  _useNumbersAsPins}}numbers{{else}}pin{{/if}}">
+  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{/compare}}{{#compare _pinStyle '=' 'numbers' }}numbers{{/compare}}{{#compare _pinStyle '=' 'default' }}pins{{/compare}}{{#unless _pinStyle}}pins{{/unless}}">
 
     <div class="hotgraphic-graphic">
 
@@ -51,7 +51,7 @@
           {{/each}}
         </div>
       </div>
-      {{#if _useGraphicsAsPins}}
+      {{#compare _pinStyle '=' 'tile' }}
         <div class="hotgraphic-narrative">
           {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
@@ -66,14 +66,14 @@
         {{/if}}
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
-            {{#if ../_useNumbersAsPins}}
+            {{#compare ../_pinStyle '=' 'numbers' }}
             <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
-            {{/if}}
+            {{/compare}}
           </button>
         {{/each}}
-      {{/if}}
+      {{/compare}}
     </div>
   </div>
 </div>

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -67,7 +67,7 @@
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#if ../_useNumbersAsPins}}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{@index}}</div>
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{math @index "+" 1}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
             {{/if}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{else}}{{#compare _pinStyle '=' 'numbers' }}numbers{{else}}pins{{/compare}}{{/compare}}">
+  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{else}}{{#if _useGraphicsAsPins}}tile{{else}}pins{{/if}}{{/compare}}">
 
     <div class="hotgraphic-graphic">
 
@@ -65,9 +65,9 @@
           <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
         {{/if}}
         {{#each _items}}
-          <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+          <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}} {{#compare ../_pinStyle '=' 'numbers' }}{{#unless _iconClass}}number{{/unless}}{{/compare}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             {{#compare ../_pinStyle '=' 'numbers' }}
-            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
+            <div class="{{#if _iconClass}}hotgraphic-graphic-pin-icon icon {{_iconClass}}{{else}}hotgraphic-graphic-number-icon{{/if}} component-item-color item-{{@index}}">{{#unless _iconClass}}{{inc @index}}{{/unless}}</div>
             {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon {{#if _iconClass}}{{_iconClass}}{{else}}icon-pin{{/if}} item-{{@index}}"></div>
             {{/compare}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{/compare}}{{#compare _pinStyle '=' 'numbers' }}numbers{{/compare}}{{#compare _pinStyle '=' 'default' }}pins{{/compare}}{{#unless _pinStyle}}pins{{/unless}}">
+  <div class="hotgraphic-widget component-widget {{#compare _pinStyle '=' 'tile' }}tile{{else}}{{#compare _pinStyle '=' 'numbers' }}numbers{{else}}pins{{/compare}}{{/compare}}">
 
     <div class="hotgraphic-graphic">
 

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -69,7 +69,7 @@
             {{#compare ../_pinStyle '=' 'numbers' }}
             <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{inc @index}}</div>
             {{else}}
-            <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+            <div class="hotgraphic-graphic-pin-icon component-item-color icon {{#if _iconClass}}{{_iconClass}}{{else}}icon-pin{{/if}} item-{{@index}}"></div>
             {{/compare}}
           </button>
         {{/each}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,7 +1,7 @@
 {{! Maintainers - Kevin Corry}}
 <div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
   {{> component this}}
-  <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else}}pin{{/if}}">
+  <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else if  _useNumbersAsPins}}numbers{{else}}pin{{/if}}">
 
     <div class="hotgraphic-graphic">
 
@@ -66,7 +66,11 @@
         {{/if}}
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+            {{#if ../_useNumbersAsPins}}
+            <div class="hotgraphic-graphic-number-icon component-item-color item-{{@index}}">{{@index}}</div>
+            {{else}}
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+            {{/if}}
           </button>
         {{/each}}
       {{/if}}


### PR DESCRIPTION
An extension of [this PR](https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/139).

Attempting to create two new attributes:

* `_pinStyle` - a string attribute which determines what type of pin is used
   * `default` - the regular pin which is used currently.
  * `tile` - currently exists as `_useGraphicsAsPins`
  * `numbers` - currently exists as `_useNumbersAsPins` in the PR above
* `_iconClass` - [suggested in this issue](https://github.com/adaptlearning/adapt_framework/issues/1574). Adds option of a class which overrides the default pin. Should work with both `default` and `numbers` pin style.

As Guy [mentions](https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/139#discussion_r120143451) this should retain backwards compatibility.