### PR TITLE
update framework dependency to satisfy future releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ When viewport size changes to the smallest range, this component will behave lik
 
 
 ----------------------------
-**Version number:**  2.1.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:**  2.0     
+**Version number:**  2.1.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Framework versions:**  2+     
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-hotgraphic/graphs/contributors)  
 **Accessibility support:** WAI AA   
 **RTL support:** yes  

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "2.1.0",
-  "framework": "^2.0.0",
+  "version": "2.1.1",
+  "framework": ">=2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-hotgraphic%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",
   "description": "A component that enables a user to click on hot spots over an image and display a detailed popup that includes an image with text.",

--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,6 @@
   "main": "/js/adapt-contrib-hotgraphic.js",
   "displayName" : "Hot Graphic",
   "component" : "hotgraphic",
-  "assetFields" : [
-    "_graphic.src",
-    "_items[]._graphic.src"
-  ],
   "keywords": [
     "adapt-plugin",
     "adapt-component"


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/1704

also remove `assetFields` from bower.json - no longer needed