### PR TITLE
Custom pins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
   "component" : "hotgraphic",
   "assetFields" : [
     "_graphic.src",
-    "_items[]._graphic.src"
+    "_items[]._graphic.src",
+    "_items[]._pin.src"
   ],
   "keywords": [
     "adapt-plugin",

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -14,6 +14,7 @@
 		background-color: @item-text-color;
 		border-radius:50%;
 		text-decoration: none;
+		line-height: 0;
 		&.visited {
 			.hotgraphic-graphic-pin-icon {
 				color: @item-color-visited;

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -11,10 +11,15 @@
 		position: absolute;
 		top: 0%;
 		left: 0%;
-		background-color: @item-text-color;
-		border-radius:50%;
+		background-color: transparent !important;
 		text-decoration: none;
 		line-height: 0;
+
+		.hotgraphic-graphic-pin-icon {
+			background-color: @item-text-color;
+			border-radius:50%;
+		}
+
 		&.visited {
 			.hotgraphic-graphic-pin-icon {
 				color: @item-color-visited;

--- a/properties.schema
+++ b/properties.schema
@@ -195,10 +195,34 @@
                 "type": "string",
                 "required": false,
                 "default": "",
-                "title": "Classes",
+                "title": "Graphic Classes",
                 "inputType": "Text",
                 "validators": [],
                 "help": ""
+              }
+            }
+          },
+          "_pin": {
+            "type": "object",
+            "required": false,
+            "title": "Item Pin",
+            "properties": {
+              "src": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": [] ,
+                "help": "The pin image leave blank for default"
+              },
+              "alt": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "inputType": "Text",
+                "validators": [],
+                "help": "Alternative text for this image",
+                "translatable": true
               }
             }
           },
@@ -206,7 +230,7 @@
             "type": "string",
             "required": false,
             "default": "",
-            "title": "Classes",
+            "title": "Component Classes",
             "inputType": "Text",
             "validators": [],
             "help": ""

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -66,7 +66,13 @@
         {{/if}}
         {{#each _items}}
           <button class="base hotgraphic-graphic-pin component-item-text-color item-{{@index}} {{#if _isVisited}}visited{{/if}}" data-id="item-{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" role="button" aria-label="Item {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
-            <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+            {{#if this._pin.src}}
+              <div class="hotgraphic-graphic-pin-image item-{{@index}}">
+                <img src="{{this._pin.src}}" aria-label="{{this._pin.alt}}">
+              </div>
+            {{else}}
+                <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+            {{/if}}
           </button>
         {{/each}}
       {{/if}}


### PR DESCRIPTION
This gives the option to upload a graphic to be used a pin rather than the current pin.

I can be custom for each item and not every item needs to use it.

I have also better named the classes inputs to help explain to users what they attach to.

One issue with this is that I have had to move the class that the pin background is on this will override any theme's that have custom overrides for hot graphic like vanilla has. 