### PR TITLE
accessibility: issue/#2203 General fixes

### DIFF
--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -61,11 +61,10 @@ define([
             if (!_isActive) return;
 
             var index = item.get('_index');
-            this.applyNavigationClasses(index);
             this.updatePageCount();
             this.handleTabs();
             this.applyItemClasses(index);
-            this.handleFocus();
+            this.handleFocus(index);
         },
 
         applyItemClasses: function(index) {
@@ -73,8 +72,9 @@ define([
             this.$('.hotgraphic-item').filter('[data-index="' + index + '"]').addClass('active');
         },
 
-        handleFocus: function() {
-            this.$('.hotgraphic-popup-inner .active').a11y_focus();
+        handleFocus: function(index) {
+            this.$('.hotgraphic-popup-inner .active').a11y_focus(true);
+            this.applyNavigationClasses(index);
         },
 
         onItemsVisitedChange: function(item, _isVisited) {

--- a/properties.schema
+++ b/properties.schema
@@ -7,23 +7,7 @@
     "ariaRegion": {
       "type": "string",
       "required": true,
-      "default": "Below is a component which allows you to select hot spots over an image. Select a hot spot to trigger a popup that includes an image with display text. Select the close button to close the popup.",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
-    "ariaPopupLabel": {
-      "type": "string",
-      "required": true,
-      "default": "Hotgraphic popup",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
-    "ariaPinLabel": {
-      "type": "string",
-      "required": true,
-      "default": "Selectable pin ",
+      "default": "Hotgraphic. Select buttons to reveal content popups.",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -149,6 +133,15 @@
             "validators": [],
             "help": "Title displayed in the popup",
             "translatable": true
+          },
+          "_ariaLevel": {
+            "type": "number",
+            "required": true,
+            "default": 0,
+            "title": "Title level",
+            "inputType": "Number",
+            "validators": ["required", "number"],
+            "help": "Aria level for title"
           },
           "body": {
             "type": "string",

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,23 +1,22 @@
-<div class="hotgraphic-inner component-inner" role="region" aria-label="{{_globals._components._hotgraphic.ariaRegion}}" {{#if _globals._components._hotgraphic.ariaRegion}}tabindex="0"{{/if}}>
+<div class="hotgraphic-inner component-inner">
   {{> component this}}
   <div class="hotgraphic-widget component-widget {{#if _useGraphicsAsPins}}tile{{else}}pin{{/if}}">
-
-    <div class="hotgraphic-graphic">
+    <div class="hotgraphic-graphic"{{#unless _useGraphicsAsPins}} role="list"{{/unless}}>
       {{#if _useGraphicsAsPins}}
-        <div class="hotgraphic-narrative">
+        <div class="hotgraphic-narrative" role="list">
           {{#each _items}}
-          <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-haspopup="dialog" aria-label="{{../_globals._components._hotgraphic.ariaPinLabel}} {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+          <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-label="{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
           </button>
           {{/each}}
         </div>
       {{else}}
-        <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" tabindex="0"/>
+        <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" />
         {{#if _graphic.attribution}}
           <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
         {{/if}}
         {{#each _items}}
-          <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-haspopup="dialog" aria-label="{{../_globals._components._hotgraphic.ariaPinLabel}} {{numbers @index}}. {{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+          <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-label="{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
             <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
           </button>
         {{/each}}

--- a/templates/hotgraphicPopup.hbs
+++ b/templates/hotgraphicPopup.hbs
@@ -3,17 +3,17 @@
     <div class="hotgraphic-item component-item clearfix {{#if _isVisited}}visited{{/if}} {{#if _isActive}}active{{/if}} {{_classes}}" data-index={{@index}}>
         <div class="hotgraphic-item-content">
             <div class="hotgraphic-item-content-inner">
-            <div class="hotgraphic-content-title" role="heading" aria-level="5" tabindex="0">
+            <div class="hotgraphic-content-title" {{a11y_attrs_heading 'componentItem'}}>
                 {{{title}}}
             </div>
             <div class="hotgraphic-content-body">
-                {{{a11y_text body}}}
+                {{{compile body}}}
             </div>
             </div>
         </div>
         <div class="hotgraphic-item-graphic">
             <div class="hotgraphic-item-graphic-inner">
-            <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" tabindex="0"/>
+            <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}"/>
             </div>
             {{#if _graphic.attribution}}
             <div class="graphic-attribution">{{{a11y_text _graphic.attribution}}}</div>
@@ -25,17 +25,17 @@
 <div class="hotgraphic-popup-toolbar component-item-color clearfix">
     {{#unless _hidePagination}}
     <div class="hotgraphic-popup-nav component-item-color">
-        <button class="base hotgraphic-popup-controls back" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="button">
+        <button class="base hotgraphic-popup-controls back" aria-label="{{_globals._accessibility._ariaLabels.previous}}">
             <div class="hotgraphic-popup-arrow-l component-item-text-color icon icon-controls-small-left"></div>
         </button>
         <div class="hotgraphic-popup-count component-item-text-color" tabindex="0">
         </div>
-        <button class="base hotgraphic-popup-controls next" aria-label="{{_globals._accessibility._ariaLabels.next}}" role="button">
+        <button class="base hotgraphic-popup-controls next" aria-label="{{_globals._accessibility._ariaLabels.next}}">
             <div class="hotgraphic-popup-arrow-r component-item-text-color icon icon-controls-small-right"></div>
         </button>
     </div>
     {{/unless}}
-    <button class="base hotgraphic-popup-done" aria-label="{{_globals._accessibility._ariaLabels.closePopup}}" role="button">
+    <button class="base hotgraphic-popup-done" aria-label="{{_globals._accessibility._ariaLabels.closePopup}}">
         <div class="hotgraphic-popup-close component-item-text-color icon icon-cross"></div>
     </button>
 </div>


### PR DESCRIPTION
[#2203](https://github.com/adaptlearning/adapt_framework/issues/2203)
* Removed `a11y_text`
* Used `a11y_attrs_heading`
* Remove div component description
* Shortened schema component description
* Fixed focus issue in popup button click
* Removed unnecessary `tabindex`
* Removed unnecessary `role="button"`
* Removed bad `aria-haspopup="dialog"` - this is for context menus only
* Using `role="list"` and `role="listitem"` removed button descriptions
* Fixed "Visited" state reading on button before popup shows

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.