### PR TITLE
issue/2451+issue/2450 Supplied notify-heading id and added aria-hidden attributes

### DIFF
--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -53,13 +53,12 @@ define([
         },
 
         handleTabs: function() {
-            this.$('.hotgraphic-popup-inner').a11y_on(false);
-            this.$('.hotgraphic-popup-inner .active').a11y_on(true);
+            this.$('.hotgraphic-item:not(.active) *').a11y_on(false);
+            this.$('.hotgraphic-item.active *').a11y_on(true);
         },
 
         onItemsActiveChange: function(item, _isActive) {
             if (!_isActive) return;
-
             var index = item.get('_index');
             this.updatePageCount();
             this.handleTabs();
@@ -68,8 +67,10 @@ define([
         },
 
         applyItemClasses: function(index) {
-            this.$('.hotgraphic-item.active').removeClass('active');
-            this.$('.hotgraphic-item').filter('[data-index="' + index + '"]').addClass('active');
+            this.$('.hotgraphic-item[data-index="' + index + '"]').addClass('active').removeAttr('aria-hidden');
+            this.$('.hotgraphic-item[data-index="' + index + '"] .hotgraphic-content-title').attr("id", "notify-heading");
+            this.$('.hotgraphic-item:not([data-index="' + index + '"])').removeClass('active').attr('aria-hidden', 'true');
+            this.$('.hotgraphic-item:not([data-index="' + index + '"]) .hotgraphic-content-title').removeAttr("id");
         },
 
         handleFocus: function(index) {

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -100,8 +100,8 @@ define([
 
             // Append the word 'visited.' to the pin's aria-label
             var visitedLabel = this.model.get('_globals')._accessibility._ariaLabels.visited + ".";
-            $pin.attr('aria-label', function(index, val) {
-                return val + " " + visitedLabel;
+            $pin.find('.aria-label').each(function(index, el) {
+                el.innerHTML = el.innerHTML + " " + visitedLabel;
             });
 
             $pin.addClass('visited');

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -8,24 +8,28 @@
           <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
         {{/if}}
         {{#each _items}}
-          <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}{{#if _pin.src}} has-pin-image{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
-            <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
-            {{#if _pin.src}}
-              <div class="hotgraphic-graphic-pin-image item-{{@index}}">
-                <img src="{{_pin.src}}" aria-label="{{_pin.alt}}">
-              </div>
-            {{else}}
-              <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
-            {{/if}}
-          </button>
+          <div class="hotgraphic-graphic-pin-list-item" role="listitem">
+            <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}{{#if _pin.src}} has-pin-image{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
+              <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
+              {{#if _pin.src}}
+                <div class="hotgraphic-graphic-pin-image item-{{@index}}">
+                  <img src="{{_pin.src}}" aria-label="{{_pin.alt}}">
+                </div>
+              {{else}}
+                <div class="hotgraphic-graphic-pin-icon component-item-color icon icon-pin item-{{@index}}"></div>
+              {{/if}}
+            </button>
+          </div>
         {{/each}}
       {{else}}
         <div class="hotgraphic-narrative" role="list">
           {{#each _items}}
-            <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
-              <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
-              <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
-            </button>
+            <div class="hotgraphic-graphic-pin-list-item" role="listitem">
+              <button class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
+                <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
+                <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
+              </button>
+            </div>
           {{/each}}
         </div>
       {{/unless}}

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -8,7 +8,8 @@
           <div class="graphic-attribution">{{{_graphic.attribution}}}</div>
         {{/if}}
         {{#each _items}}
-          <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}{{#if _pin.src}} has-pin-image{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-label="{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+          <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}}{{#if _pin.src}} has-pin-image{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
+            <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
             {{#if _pin.src}}
               <div class="hotgraphic-graphic-pin-image item-{{@index}}">
                 <img src="{{_pin.src}}" aria-label="{{_pin.alt}}">
@@ -21,7 +22,8 @@
       {{else}}
         <div class="hotgraphic-narrative" role="list">
           {{#each _items}}
-            <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;" aria-label="{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}">
+            <button role="listitem" class="base hotgraphic-graphic-pin component-item-text-color {{#if _isVisited}}visited{{/if}} hotgraphic-graphic-pin-{{@index}} {{#if _graphic._classes}}{{_graphic._classes}}{{/if}}" data-index="{{@index}}" style="top:{{{_top}}}%; left:{{{_left}}}%;">
+              <span class="aria-label">{{title}}.{{#if _isVisited}} {{../_globals._accessibility._ariaLabels.visited}}.{{/if}}</span>
               <div class="hotgraphic-graphic-pin-image component-item-color item-{{@index}}" style="background-image: url({{_graphic.src}})"></div>
             </button>
           {{/each}}

--- a/templates/hotgraphicPopup.hbs
+++ b/templates/hotgraphicPopup.hbs
@@ -1,9 +1,9 @@
 <div class="hotgraphic-popup-inner clearfix">
     {{#each _items}}
-    <div class="hotgraphic-item component-item clearfix {{#if _isVisited}}visited{{/if}} {{#if _isActive}}active{{/if}} {{_classes}}" data-index={{@index}}>
+    <div class="hotgraphic-item component-item clearfix {{#if _isVisited}}visited{{/if}} {{#if _isActive}}active{{/if}} {{_classes}}" {{#unless _isActive}} aria-hidden="true"{{/unless}} data-index={{@index}}>
         <div class="hotgraphic-item-content">
             <div class="hotgraphic-item-content-inner">
-            <div class="hotgraphic-content-title" {{a11y_attrs_heading 'componentItem'}}>
+            <div{{#if _isActive}} id="notify-heading"{{/if}} class="hotgraphic-content-title" {{a11y_attrs_heading 'componentItem'}}>
                 {{{title}}}
             </div>
             <div class="hotgraphic-content-body">


### PR DESCRIPTION
[#2451](https://github.com/adaptlearning/adapt_framework/issues/2451)
* added `id="notify-heading"` to correspond to the notify `aria-labelledby` attribute
* added `aria-hidden="true"` to the hidden hotgraphic popup items
* made `a11y_on` use more specific

[#2450](https://github.com/adaptlearning/adapt_framework/issues/2450)
* moved `role=listitem` `aria-label` from div to inner for better screen reader + browser compatibility

It should now read the active item heading when opening any item, always.