### PR TITLE
Set popup count line height

### DIFF
--- a/less/hotgraphicPopup.less
+++ b/less/hotgraphicPopup.less
@@ -29,6 +29,7 @@
 
   &__count {
     padding: @icon-padding;
+    line-height: 1;
   }
 
   &__controls.is-disabled {


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2933

* Set line height of the hotgraphic popup count area to 1 