### PR TITLE
Added aria-hidden to pin number

### DIFF
--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -32,7 +32,9 @@
           {{else}}
 
           {{#if ../_useNumberedPins}}
-          <div class="hotgraphic__pin-number">{{math @index "+" 1}}</div>
+          <div class="hotgraphic__pin-number" aria-hidden="true">
+            {{math @index "+" 1}}
+          </div>
           {{else}}
           <div class="icon"></div>
           {{/if}}


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2948

* Added an aria-hidden attribute to `.hotgraphic__pin-number` stop duplicate numbers being read out by screen readers