### PR TITLE
Prevent toggleHidden from targeting child elements causing images without 'alt' to be read by screen reader

### DIFF
--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -59,8 +59,8 @@ define([
     }
 
     handleTabs() {
-      Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item:not(.is-active) *'), true);
-      Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item.is-active *'), false);
+      Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item:not(.is-active)'), true);
+      Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item.is-active'), false);
     }
 
     onItemsActiveChange(item, _isActive) {


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2968