### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ This optional text appears above the component. It is frequently used to
 guide the learner’s interaction with the component.
 
 ### mobileBody (string):
-This is optional text that will be substituted for `body` when `Adapt.device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`).
+This is optional text that will be substituted for `body` when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`).
 
 ### mobileInstruction (string):
-This is optional text that will be substituted for `instruction` when `Adapt.device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`).
+This is optional text that will be substituted for `instruction` when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`).
 
 ### \_setCompletionOn (string):
 Determines when Adapt will register this component as having been completed by the learner. Acceptable values are `"allItems"` and `"inview"`. `"allItems"` requires each pop-up item to be visited. `"inview"` requires the **Hot Graphic** component to enter the view port completely.
@@ -111,7 +111,7 @@ ARIA level to assign to the popup title. If not set, it will default to using th
 This is the main text for a hot spot pop-up.
 
 #### strapline (string):
-This text is displayed when `Adapt.device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`). It is presented in a title bar above the image.
+This text is displayed when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`). It is presented in a title bar above the image.
 
 #### \_classes (string):
 CSS class name(s) to be applied to the popup item. Classes available by default are:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-hotgraphic",
   "version": "5.5.1",
-  "framework": ">=5.17.2",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues",
   "component" : "hotgraphic",

--- a/js/adapt-contrib-hotgraphic.js
+++ b/js/adapt-contrib-hotgraphic.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import HotgraphicView from './hotgraphicView';
 import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 
-export default Adapt.register('hotgraphic', {
+export default components.register('hotgraphic', {
   model: ItemsComponentModel.extend({}),
   view: HotgraphicView
 });

--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import a11y from 'core/js/a11y';
 
 class HotgraphicPopupView extends Backbone.View {
 
@@ -18,7 +19,7 @@ class HotgraphicPopupView extends Backbone.View {
     // Debounce required as a second (bad) click event is dispatched on iOS causing a jump of two items.
     this.onControlClick = _.debounce(this.onControlClick.bind(this), 100);
     this.listenToOnce(Adapt, 'notify:opened', this.onOpened);
-    this.listenTo(this.model.get('_children'), {
+    this.listenTo(this.model.getChildren(), {
       'change:_isActive': this.onItemsActiveChange,
       'change:_isVisited': this.onItemsVisitedChange
     });
@@ -43,8 +44,8 @@ class HotgraphicPopupView extends Backbone.View {
       .toggleClass('first', !shouldEnableBack)
       .toggleClass('last', !shouldEnableNext);
 
-    Adapt.a11y.toggleAccessibleEnabled($controls.filter('.back'), shouldEnableBack);
-    Adapt.a11y.toggleAccessibleEnabled($controls.filter('.next'), shouldEnableNext);
+    a11y.toggleAccessibleEnabled($controls.filter('.back'), shouldEnableBack);
+    a11y.toggleAccessibleEnabled($controls.filter('.next'), shouldEnableNext);
   }
 
   updatePageCount() {
@@ -57,8 +58,8 @@ class HotgraphicPopupView extends Backbone.View {
   }
 
   handleTabs() {
-    Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item:not(.is-active)'), true);
-    Adapt.a11y.toggleHidden(this.$('.hotgraphic-popup__item.is-active'), false);
+    a11y.toggleHidden(this.$('.hotgraphic-popup__item:not(.is-active)'), true);
+    a11y.toggleHidden(this.$('.hotgraphic-popup__item.is-active'), false);
   }
 
   onItemsActiveChange(item, _isActive) {
@@ -78,7 +79,7 @@ class HotgraphicPopupView extends Backbone.View {
   }
 
   handleFocus(index) {
-    Adapt.a11y.focusFirst(this.$('.hotgraphic-popup__inner .is-active'));
+    a11y.focusFirst(this.$('.hotgraphic-popup__inner .is-active'));
     this.applyNavigationClasses(index);
   }
 

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -1,4 +1,8 @@
 import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
+import data from 'core/js/data';
+import device from 'core/js/device';
+import notify from 'core/js/notify';
 import ComponentView from 'core/js/views/componentView';
 import HotgraphicPopupView from './hotgraphicPopupView';
 
@@ -31,20 +35,20 @@ class HotGraphicView extends ComponentView {
   setUpEventListeners() {
     this.listenTo(Adapt, 'device:changed', this.reRender);
 
-    this.listenTo(this.model.get('_children'), {
+    this.listenTo(this.model.getChildren(), {
       'change:_isActive': this.onItemsActiveChange,
       'change:_isVisited': this.onItemsVisitedChange
     });
   }
 
   reRender() {
-    if (Adapt.device.screenSize === 'large' || this.model.get('_isNarrativeOnMobile') === false) return;
+    if (device.screenSize === 'large' || this.model.get('_isNarrativeOnMobile') === false) return;
 
     this.replaceWithNarrative();
   }
 
   replaceWithNarrative() {
-    const NarrativeView = Adapt.getViewClass('narrative');
+    const NarrativeView = components.getViewClass('narrative');
     if (!NarrativeView) return;
 
     const model = this.prepareNarrativeModel();
@@ -53,7 +57,7 @@ class HotGraphicView extends ComponentView {
     // this.$el.parents() won't exist at this point - which is why the following is
     // written the way it is, instead of (what would appear to be) the more efficient
     // this.$el.parents('.component__container')
-    const $container = Adapt.findViewByModelId(model.get('_parentId')).$el.find('.component__container');
+    const $container = data.findViewByModelId(model.get('_parentId')).$el.find('.component__container');
     $container.append(newNarrative.$el);
 
     this.remove();
@@ -110,7 +114,7 @@ class HotGraphicView extends ComponentView {
   }
 
   preRender() {
-    if (Adapt.device.screenSize === 'large') {
+    if (device.screenSize === 'large') {
       this.render();
       return;
     }
@@ -141,7 +145,7 @@ class HotGraphicView extends ComponentView {
       model: this.model
     });
 
-    Adapt.notify.popup({
+    notify.popup({
       _view: this.popupView,
       _isCancellable: true,
       _showCloseButton: false,


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to components.register from Adapt.register
* `model.getChildren()` instead of `model.get('_children')`
* Using `device`, `notify` , `data` and `a11y` directly