### PR TITLE
add "_isMobileTextBelowImage"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ This is optional text that will be substituted for `body` when `device.screenSiz
 ### mobileInstruction (string):
 This is optional text that will be substituted for `instruction` when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`).
 
+### \_isMobileTextBelowImage (boolean):
+Like `mobileBody` and `mobileInstruction`, `_isMobileTextBelowImage` is only applicable when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`). The default is `false`. When set to `true`, the replacement Narrative will not use the default "strapline" layout. Instead both the image and text of each stage remain visible, with the text positioned below the image. 
+
 ### \_setCompletionOn (string):
 Determines when Adapt will register this component as having been completed by the learner. Acceptable values are `"allItems"` and `"inview"`. `"allItems"` requires each pop-up item to be visited. `"inview"` requires the **Hot Graphic** component to enter the view port completely.
 

--- a/properties.schema
+++ b/properties.schema
@@ -103,6 +103,15 @@
       "help": "This instruction text is displayed on mobile devices when this component turns into a Narrative",
       "translatable": true
     },
+    "_isMobileTextBelowImage": {
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "title": "Move text area below image on mobile device",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "When Hot Graphic is displayed on a mobile device, it turns into a Narrative. If you check this box, the text content of each stage is positioned below the image. The Narrative will not use the default \"strapline\" layout."
+    },
     "_hidePagination": {
       "type": "boolean",
       "required": true,


### PR DESCRIPTION
This PR adds a schema attribute that configures the mobile Narrative. Enabling the attribute bypasses the "strapline" layout and positions the text of each stage below its image.

fixes #224 