### PR TITLE
#232 Resolves Add completion statuses when using tile layout

### DIFF
--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -39,20 +39,20 @@
   &__tile {
     position: relative;
     width: 100%;
+  }
 
-    .icon {
-      position: absolute;
-      bottom: 1.0rem;
-      right: 1.0rem;
-      padding: @icon-padding / 2;
+  &__tile .icon {
+    position: absolute;
+    bottom: 1.0rem;
+    right: 1.0rem;
+    padding: @icon-padding / 2;
 
-      @media (min-width: @device-width-medium) {
-        padding: @icon-padding;
-      }
-
-      .is-visited& {
-        .icon-tick;
-      }
+    @media (min-width: @device-width-medium) {
+      padding: @icon-padding;
     }
+  }
+
+  &__tile.is-visited .icon {
+    .icon-tick;
   }
 }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -44,6 +44,11 @@
       position: absolute;
       bottom: 1.0rem;
       right: 1.0rem;
+      padding: @icon-padding / 2;
+
+      @media (min-width: @device-width-medium) {
+        padding: @icon-padding;
+      }
 
       .is-visited& {
         .icon-tick;

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -37,6 +37,17 @@
   }
 
   &__tile {
+    position: relative;
     width: 100%;
+
+    .icon {
+      position: absolute;
+      bottom: 1.0rem;
+      right: 1.0rem;
+
+      .is-visited& {
+        .icon-tick;
+      }
+    }
   }
 }

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -61,7 +61,7 @@
 
           <img class="hotgraphic__tile-image" src="{{_graphic.src}}">
 
-          <div class="icon"></div>
+          <div class="icon" aria-hidden="true"></div>
 
         </button>
 

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -61,6 +61,8 @@
 
           <img class="hotgraphic__tile-image" src="{{_graphic.src}}">
 
+          <div class="icon"></div>
+
         </button>
 
       </div>


### PR DESCRIPTION
Resolves #232 

Adds a checkmark icon when the item has been visited.

![hotgraphic-tile-visited](https://user-images.githubusercontent.com/898168/176514702-f6d1a720-1e20-46b1-9777-b609d0c60dbb.jpg)

Better styling to be added to the **theme**: https://github.com/adaptlearning/adapt-contrib-vanilla/issues/335