### PR TITLE
Update: Remove 'visibility: hidden' from disabled popup paging buttons (fixes #241)

### DIFF
--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -44,8 +44,8 @@ class HotgraphicPopupView extends Backbone.View {
       .toggleClass('first', !shouldEnableBack)
       .toggleClass('last', !shouldEnableNext);
 
-    a11y.toggleAccessibleEnabled($controls.filter('.back'), shouldEnableBack);
-    a11y.toggleAccessibleEnabled($controls.filter('.next'), shouldEnableNext);
+    a11y.toggleEnabled($controls.filter('.back'), shouldEnableBack);
+    a11y.toggleEnabled($controls.filter('.next'), shouldEnableNext);
   }
 
   updatePageCount() {

--- a/less/hotgraphicPopup.less
+++ b/less/hotgraphicPopup.less
@@ -32,10 +32,6 @@
     line-height: 1;
   }
 
-  &__controls.is-disabled {
-    visibility: hidden;
-  }
-
   // Pop up item
   // --------------------------------------------------
   &__item-image-container {


### PR DESCRIPTION
Fixes #241 

### Update
* Removes 'visibility: hidden' from Hotgraphic popup disabled paging buttons

### Testing
1. Add a Hotgraphic component to a course.
1. Click on an item to open the Notify popup.
1. The disabled buttons should be visible.

Requires https://github.com/adaptlearning/adapt-contrib-core/pull/221
