### PR TITLE
Fix: Use carousel behaviour from wcag

### DIFF
--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -27,9 +27,11 @@ class HotgraphicPopupView extends Backbone.View {
   }
 
   onOpened() {
-    this.applyNavigationClasses(this.model.getActiveItem().get('_index'));
+    const index = this.model.getActiveItem().get('_index');
+    this.applyNavigationClasses(index);
     this.updatePageCount();
     this.handleTabs();
+    this.evaluateNavigation(index);
   }
 
   applyNavigationClasses (index) {
@@ -130,9 +132,46 @@ class HotgraphicPopupView extends Backbone.View {
     this.model.getActiveItem().toggleActive();
 
     const nextItem = this.model.getItem(index);
+    this.evaluateNavigation(index);
     nextItem.toggleActive();
     nextItem.toggleVisited(true);
   }
+
+  evaluateNavigation(index) {
+    const active = index || 0;
+    const itemCount = this.model.getChildren().length;
+
+    const isAtStart = active === 0;
+    const isAtEnd = active === itemCount - 1;
+
+    const $left = this.$('.hotgraphic-popup__controls.back');
+    const $right = this.$('.hotgraphic-popup__controls.next');
+
+    const globals = Adapt.course.get('_globals');
+
+    const ariaLabelsGlobals = globals._accessibility._ariaLabels;
+    const hotGraphicGlobals = globals._components._hotgraphic;
+
+    const ariaLabelPrevious = hotGraphicGlobals.previous || ariaLabelsGlobals.previous;
+    const ariaLabelNext = hotGraphicGlobals.next || ariaLabelsGlobals.next;
+
+    const prevTitle = isAtStart ? '' : this.model.getItem(active - 1).get('title');
+    const nextTitle = isAtEnd ? '' : this.model.getItem(active + 1).get('title');
+
+    $left.attr('aria-label', Handlebars.helpers.compile_a11y_normalize(ariaLabelPrevious, {
+      title: prevTitle,
+      _globals: globals,
+      itemNumber: isAtStart ? null : active,
+      totalItems: itemCount
+    }));
+    $right.attr('aria-label', Handlebars.helpers.compile_a11y_normalize(ariaLabelNext, {
+      title: nextTitle,
+      _globals: globals,
+      itemNumber: isAtEnd ? null : active + 2,
+      totalItems: itemCount
+    }));
+
+  };
 
 };
 

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -106,9 +106,9 @@ class HotGraphicView extends ComponentView {
 
     const $pin = this.getItemElement(model);
     // Append the word 'visited.' to the pin's aria-label
-    const visitedLabel = ` ${this.model.get('_globals')._accessibility._ariaLabels.visited}.`;
+    const visitedLabel = ` ${this.model.get('_globals')._accessibility._ariaLabels.visited}. `;
     $pin.find('.aria-label').each((index, el) => {
-      el.innerHTML += visitedLabel;
+      el.innerHTML = visitedLabel + el.innerHTML;
     });
 
     $pin.addClass('is-visited');

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -20,6 +20,7 @@ class HotGraphicView extends ComponentView {
     this.setUpViewData();
     this.setUpModelData();
     this.setUpEventListeners();
+    this.updateItemCount();
   }
 
   setUpViewData() {
@@ -161,6 +162,26 @@ class HotGraphicView extends ComponentView {
   onPopupClosed() {
     this.model.getActiveItem().toggleActive();
     this._isPopupOpen = false;
+  }
+
+  updateItemCount () {
+    const NarrativeView = components.getViewClass('narrative');
+    if (NarrativeView) return;
+
+    const items = this.model.getChildren();
+    const globals = Adapt.course.get('_globals');
+    const hotGraphicGlobals = globals._components._hotgraphic;
+    const ariaLabelItem = hotGraphicGlobals.item;
+
+    items.forEach((element, index) => {
+      const $ariaLabel = this.$('button span.aria-label')[index];
+      const title = Handlebars.helpers.compile_a11y_normalize(ariaLabelItem, {
+        itemNumber: index + 1,
+        totalItems: items.length
+      });
+
+      $ariaLabel.textContent += ` ${title}`;
+    });
   }
 
 }

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -165,9 +165,6 @@ class HotGraphicView extends ComponentView {
   }
 
   updateItemCount () {
-    const NarrativeView = components.getViewClass('narrative');
-    if (NarrativeView) return;
-
     const items = this.model.getChildren();
     const globals = Adapt.course.get('_globals');
     const hotGraphicGlobals = globals._components._hotgraphic;

--- a/properties.schema
+++ b/properties.schema
@@ -12,6 +12,14 @@
       "validators": [],
       "translatable": true
     },
+    "item": {
+      "type": "string",
+      "title": "Item",
+      "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
+      "_adapt": {
+        "translatable": true
+      }
+    },
     "previous": {
       "type": "string",
       "title": "Previous",

--- a/properties.schema
+++ b/properties.schema
@@ -12,6 +12,22 @@
       "validators": [],
       "translatable": true
     },
+    "previous": {
+      "type": "string",
+      "title": "Previous",
+      "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+      "_adapt": {
+        "translatable": true
+      }
+    },
+    "next": {
+      "type": "string",
+      "title": "Next",
+      "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+      "_adapt": {
+        "translatable": true
+      }
+    },
     "popupPagination": {
       "type": "string",
       "required": true,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,6 +24,22 @@
                     "translatable": true
                   }
                 },
+                "previous": {
+                  "type": "string",
+                  "title": "Previous",
+                  "default": "{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "next": {
+                  "type": "string",
+                  "title": "Next",
+                  "default": "{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
                 "popupPagination": {
                   "type": "string",
                   "title": "Popup pagination",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,6 +24,14 @@
                     "translatable": true
                   }
                 },
+                "item": {
+                  "type": "string",
+                  "title": "Item",
+                  "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
                 "previous": {
                   "type": "string",
                   "title": "Previous",

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -1,3 +1,4 @@
+{{import_globals}}
 <div class="component__inner hotgraphic__inner">
 
   {{> component this}}
@@ -23,7 +24,7 @@
 
         <button class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
 
-          <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}. Item {{math @index "+" 1}} of {{../_items.length}}</span>
+          <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}.</span>
 
           {{#if _pin.src}}
           <span class="hotgraphic__pin-image-container item-{{@index}}">

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -23,7 +23,7 @@
 
         <button class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
 
-          <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}.</span>
+          <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}. Item {{math @index "+" 1}} of {{../_items.length}}</span>
 
           {{#if _pin.src}}
           <span class="hotgraphic__pin-image-container item-{{@index}}">

--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -22,7 +22,7 @@
       {{#each _items}}
       <div class="hotgraphic__pin-item" role="listitem">
 
-        <button class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
+        <button aria-haspopup="dialog" class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
 
           <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}.</span>
 
@@ -56,7 +56,7 @@
       {{#each _items}}
       <div class="hotgraphic__tile-item" role="listitem">
 
-        <button class="hotgraphic__tile item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}">
+        <button aria-haspopup="dialog" class="hotgraphic__tile item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}">
 
           <span class="aria-label">{{{compile title}}}.</span>
 

--- a/templates/hotgraphicPopup.hbs
+++ b/templates/hotgraphicPopup.hbs
@@ -50,20 +50,20 @@
   <div class="hotgraphic-popup__nav">
 
     <button data-direction="back" class="btn-icon hotgraphic-popup__controls back js-hotgraphic-controls-click" aria-label="{{_globals._accessibility._ariaLabels.previous}}">
-      <span class="icon"></span>
+      <span class="icon" aria-hidden="true"></span>
     </button>
 
-    <div class="hotgraphic-popup__count"></div>
+    <div class="hotgraphic-popup__count" aria-hidden="true"></div>
 
     <button data-direction="next" class="btn-icon hotgraphic-popup__controls next js-hotgraphic-controls-click" aria-label="{{_globals._accessibility._ariaLabels.next}}">
-      <span class="icon"></span>
+      <span class="icon" aria-hidden="true"></span>
     </button>
 
   </div>
   {{/unless}}
 
   <button class="btn-icon hotgraphic-popup__close js-hotgraphic-popup-close" aria-label="{{_globals._accessibility._ariaLabels.closePopup}}">
-    <span class="icon"></span>
+    <span class="icon" aria-hidden="true"></span>
   </button>
 
 </div>


### PR DESCRIPTION
Fixes: https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/243

### Fix
* Align the accessibility with wcag for carousel behaviour. 

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Interact with the hotgraphic using a screen reader
2. Check that all items are read out as a list
3. Open a popup and ensure that nav buttons are reading out which item is next/back

