### PR TITLE
Fix: aria-haspopup removed from hotgraphic buttons (Fixes #257)

### DIFF
--- a/templates/hotgraphic.hbs
+++ b/templates/hotgraphic.hbs
@@ -22,7 +22,7 @@
       {{#each _items}}
       <div class="hotgraphic__pin-item" role="listitem">
 
-        <button aria-haspopup="dialog" class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
+        <button class="btn-icon hotgraphic__pin item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _pin.src}} has-pin-image{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}" style="top: {{{_top}}}%; left: {{{_left}}}%;">
 
           <span class="aria-label">{{#if ../_useNumberedPins}}{{math @index "+" 1}} {{/if}}{{#if _pin.alt}}{{{compile _pin.alt}}}{{else}}{{{compile title}}}{{/if}}.</span>
 
@@ -56,7 +56,7 @@
       {{#each _items}}
       <div class="hotgraphic__tile-item" role="listitem">
 
-        <button aria-haspopup="dialog" class="hotgraphic__tile item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}">
+        <button class="hotgraphic__tile item-{{@index}}{{#if _graphic._classes}} {{_graphic._classes}}{{/if}}{{#if _isVisited}} is-visited{{/if}} js-hotgraphic-item-click" data-index="{{@index}}">
 
           <span class="aria-label">{{{compile title}}}.</span>
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes (#257)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* aria-haspopup removed from hotgraphic buttons (#257)

### Testing
1. Using Jaws navigate to Hotgraphic
2. Move between pins using keyboard arrows
3. Open an item and close
4. Use arrows to move to a different pin to check it's not just scrolling the page

aria-haspopup has some issues with various screen readers and is not fully compatible (https://www.digitala11y.com/aria-haspopup-properties/). Looking through github threads, this has been an issue for years and has not been resolved, best to remove entirely. 



