### PR TITLE
Fix: Item popup title missing ARIA heading role (fixes #265)

### DIFF
--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -46,6 +46,7 @@ export default function HotgraphicPopup(props) {
                   'hotgraphic-popup__item-title',
                   _isActive && 'notify-heading'
                 ])}
+                role="heading"
                 aria-level={a11y.ariaLevel({ level: 'notify' })}
               >
                 <div


### PR DESCRIPTION
The popup title, `.hotgraphic-popup__item-title` is read by a screen reader but it isn't announced as a 'heading' neither is the heading level announced.

The current implementation doesn't have a `role='heading'` assigned which is required for `aria-level` to read.

Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/265