### PR TITLE
Fix: Replace hotgraphic view with narrative view on parent

### DIFF
--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -38,10 +38,7 @@ class HotGraphicView extends ComponentView {
 
     const model = this.model.prepareNarrativeModel();
     const newNarrative = new NarrativeView({ model });
-    // NOTE: if this component is doing its inital render in 'narrative mode',
-    // this.$el.parents() won't exist at this point - which is why the following is
-    // written the way it is, instead of (what would appear to be) the more efficient
-    // this.$el.parents('.component__container')
+
     const parentView = data.findViewByModelId(model.get('_parentId'));
     const $container = parentView.$el.find('.component__container');
     $container.append(newNarrative.$el);


### PR DESCRIPTION
fixes #267 

### Fix
* Replace hotgraphic view with narrative view on parent, allowing for clearup on page destruction