### PR TITLE
Fix: compile reactHelpers (fixes #273)

### DIFF
--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import a11y from 'core/js/a11y';
-import { classes, templates } from 'core/js/reactHelpers';
+import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function HotgraphicPopup(props) {
 
@@ -60,7 +60,7 @@ export default function HotgraphicPopup(props) {
               <div className="hotgraphic-popup__item-body">
                 <div
                   className="hotgraphic-popup__item-body-inner"
-                  dangerouslySetInnerHTML={{ __html: body }}
+                  dangerouslySetInnerHTML={{ __html: compile(body) }}
                 />
               </div>
               }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/273

To support [a11y_alt_text](https://github.com/adaptlearning/adapt-contrib-core/commit/a92c7ffdb431bdf126e080c009b3b9c324642755) helper tag.