### PR TITLE
Update: add generic .notify__btn-icon class (fixes #275)

### DIFF
--- a/templates/hotgraphicPopupToolbar.jsx
+++ b/templates/hotgraphicPopupToolbar.jsx
@@ -33,7 +33,7 @@ export default function HotgraphicPopupToolbar(props) {
 
         <button
           className={classes([
-            'btn-icon hotgraphic-popup__controls back',
+            'btn-icon notify__btn-icon hotgraphic-popup__controls back',
             !shouldEnableBack && 'is-disabled'
           ])}
           aria-label={backLabel}
@@ -52,7 +52,7 @@ export default function HotgraphicPopupToolbar(props) {
 
         <button
           className={classes([
-            'btn-icon hotgraphic-popup__controls next',
+            'btn-icon notify__btn-icon hotgraphic-popup__controls next',
             !shouldEnableNext && 'is-disabled'
           ])}
           aria-label={nextLabel}
@@ -67,7 +67,7 @@ export default function HotgraphicPopupToolbar(props) {
       }
 
       <button
-        className="btn-icon hotgraphic-popup__close"
+        className="btn-icon notify__btn-icon hotgraphic-popup__close"
         aria-label={ariaLabels.closePopup}
         onClick={onCloseClick}
       >


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/275

Apply `.notify__btn-icon` to popup icon buttons to inherit styles from [Vanilla notify.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/142b4fde60d638e280d04d691c63fbe62bd5abfe/less/core/notify.less#LL74C3-L86C4).

Once merged, we can remove the duplicate code from [Vanilla hotgraphicPopup.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/142b4fde60d638e280d04d691c63fbe62bd5abfe/less/plugins/adapt-contrib-hotgraphic/hotgraphicPopup.less#LL9C1-L22C4). This means the default style is set in one place but we still have plugin specific classes to target should you want to style these different - although there's good reason for keeping UI button styling consistent.