### PR TITLE
Fix: compile title (fixes #273)

### DIFF
--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -51,7 +51,7 @@ export default function HotgraphicPopup(props) {
               >
                 <div
                   className="hotgraphic-popup__item-title-inner"
-                  dangerouslySetInnerHTML={{ __html: title }}
+                  dangerouslySetInnerHTML={{ __html: compile(title) }}
                 />
               </div>
               }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/273

To support [a11y_alt_text](https://github.com/adaptlearning/adapt-contrib-core/commit/a92c7ffdb431bdf126e080c009b3b9c324642755) helper tag.

## PR Test
Add `a11y_alt_text` helper to Hotgraphic item `title` e.g. `{{a11y_alt_text '$5bn' 'five billion dollars'}}`.

In your course, go to the Hotgraphic item and trigger popup. The `a11y_alt_text` helper syntax shouldn't be visible within the popup display text and instead should just display '$5bn'.

Using the browser devtools, inspect '$5bn' and the helper should have split out the on screen text and a11y text e.g.
`<span aria-hidden="true">$5bn</span><span class="aria-label">five billion dollars</span>`