### PR TITLE
Fix: Defer replaceWithNarrative (fixes #278)

### DIFF
--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -29,7 +29,9 @@ class HotGraphicView extends ComponentView {
   reRender() {
     if (device.isScreenSizeMin('medium') || this.model.get('_isNarrativeOnMobile') === false) return;
 
-    this.replaceWithNarrative();
+    _.defer(() => {
+      this.replaceWithNarrative();
+    });
   }
 
   replaceWithNarrative() {

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -45,8 +45,8 @@ class HotGraphicView extends ComponentView {
     const $container = parentView.$el.find('.component__container');
     $container.append(newNarrative.$el);
 
-    const parentChildViews = parentView.getChildViews() || [];
-    const currentIndex = parentChildViews.findIndex(view => view === this);
+    const parentChildViews = parentView.getChildViews();
+    const currentIndex = parentChildViews?.findIndex(view => view === this) ?? 0;
     parentChildViews[currentIndex] = newNarrative;
     parentView.setChildViews(parentChildViews);
 

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -45,7 +45,7 @@ class HotGraphicView extends ComponentView {
     const $container = parentView.$el.find('.component__container');
     $container.append(newNarrative.$el);
 
-    const parentChildViews = parentView.getChildViews();
+    const parentChildViews = parentView.getChildViews() || [];
     const currentIndex = parentChildViews.findIndex(view => view === this);
     parentChildViews[currentIndex] = newNarrative;
     parentView.setChildViews(parentChildViews);


### PR DESCRIPTION
Fixes #278 

### Fix
* Defers `replaceWithNarrative()` so that `parentChildViews` can be set first on the block

If this is the correct solution, will **Narrative** need this fix as well? Should `replaceWithHotgraphic()` be deferred [here](https://github.com/adaptlearning/adapt-contrib-narrative/blob/df16db442163bd575da72d41d54cd8b9766799d3/js/NarrativeView.js#L159)?


Also created a new [issue](https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/280) regarding the component position.