### PR TITLE
Update: Display visited state for numbered pins (fixes #255)

### DIFF
--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -71,13 +71,13 @@ export default function HotgraphicLayoutPins(props) {
                 </span>
                 }
 
-                {!_pin.src && _useNumberedPins &&
+                {(!_pin.src && _useNumberedPins && !_isVisited) &&
                   <span className="hotgraphic__pin-number" aria-hidden="true">
                     {index + 1}
                   </span>
                 }
 
-                {!_pin.src && !_useNumberedPins &&
+                {((!_pin.src && !_useNumberedPins) || (!_pin.src && _isVisited)) &&
                   <span className="icon" aria-hidden="true" />
                 }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/255

When using `_useNumberedPins: true`, on visiting an item, replace the pin number with the visited tick for consistency with other component item visited states.

## Question (now raised as new issue https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/282)
With the current implementation, the visited state pin displays larger as this inherits from `@icon-size` (`1.5rem`) whereas the number pin inherits from `@body-size` (`1rem`). Is this fine as is? See screenshot below.

<img width="1491" alt="current_numbers" src="https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7045330/a3b01529-b925-4a96-a6fd-f38734ad14b1">


Alternatively, we could update the `.hotgraphic__pin-number` to inherit the icon styles instead. See screenshot below.

<img width="1499" alt="numbers_inherit_from_icon" src="https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7045330/2321efeb-df6b-4db4-9e91-d0b4491c1f81">
