### PR TITLE
Update: Remove _ariaLevel override property (fixes #287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,6 @@ Enter a percentage value (0-100) that this item should be from the left border o
 #### title (string):
 This is the title text for the hot spot's pop-up.
 
-#### \_ariaLevel (number):
-ARIA level to assign to the popup title. If not set, it will default to using the value assigned to `_notify` in the `_accessibility` section of config.json.
-
 #### body (string):
 This is the main text for a hot spot pop-up.
 

--- a/properties.schema
+++ b/properties.schema
@@ -208,15 +208,6 @@
             "help": "Title displayed in the popup",
             "translatable": true
           },
-          "_ariaLevel": {
-            "type": "number",
-            "required": true,
-            "default": 0,
-            "title": "Title level",
-            "inputType": "Number",
-            "validators": ["required", "number"],
-            "help": "ARIA level to assign to the popup title. Leave set to 0 to default to the Notify ARIA level (set via the Accessibility section of the course configuration)."
-          },
           "body": {
             "type": "string",
             "required": true,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -146,12 +146,6 @@
                   "translatable": true
                 }
               },
-              "_ariaLevel": {
-                "type": "number",
-                "title": "Title ARIA level",
-                "description": "ARIA level to assign to the popup title. Leave set to 0 to default to the Notify ARIA level (set via the Accessibility section of the course configuration)",
-                "default": 0
-              },
               "body": {
                 "type": "string",
                 "title": "Body",


### PR DESCRIPTION
Popup title `_ariaLevel` override removed.

Notify is a modal element where navigation is confined to the container so the first title within this should be `aria-level="1"` which is inherited from Notify.

`_ariaLevels` were [automated in Core](https://github.com/adaptlearning/adapt-contrib-core/pull/146), there's no need to manually override these now.

Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/287
