### PR TITLE
Update: expand _imageAlignment properties and set popup item DOM order (fixes #289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This is the main text for a hot spot pop-up.
 This text is displayed when `device.screenSize` is `small` (i.e. when viewed on mobile devices, except when the [_isNarrativeOnMobile](#_isnarrativeonmobile-boolean) setting is set to `false`). It is presented in a title bar above the image.
 
 #### \_imageAlignment (string):
-Defines the horizontal alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Right: Image aligned to the right of the text area. The default alignment is `right`.
+Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 
 #### \_classes (string):
 CSS class name(s) to be applied to the popup item. Classes available by default are:

--- a/less/hotgraphicPopup.less
+++ b/less/hotgraphicPopup.less
@@ -34,24 +34,11 @@
 
   // Pop up item
   // --------------------------------------------------
-  &__item-image-container {
-    width: 60%;
-    margin: auto;
-  }
-
   @media (min-width: @device-width-medium) {
     &__item {
       display: flex;
-      align-items: flex-start;
-    }
-
-    &__item-content {
-      width: 60%;
-    }
-
-    &__item-image-container {
-      width: 40%;
-      margin-left: @item-padding;
+      flex-direction: column;
+      row-gap: 1rem;
     }
   }
 
@@ -81,16 +68,23 @@
     .u-display-none;
   }
 
-  // Align hotgraphic pop up image to the left
+  // Hotgraphic pop up image alignment
   // --------------------------------------------------
   @media (min-width: @device-width-medium) {
-    &__item.align-image-left {
-      flex-direction: row-reverse;
+    &__item.align-image-left,
+    &__item.align-image-right {
+      flex-direction: row;
+      column-gap: 1rem;
     }
 
-    &__item.align-image-left &__item-image-container {
-      margin-left: inherit;
-      margin-right: @item-padding;
+    &__item.align-image-left &__item-content,
+    &__item.align-image-right &__item-content {
+      width: 60%;
+    }
+
+    &__item.align-image-left &__item-image-container,
+    &__item.align-image-right &__item-image-container {
+      width: 40%;
     }
   }
 

--- a/properties.schema
+++ b/properties.schema
@@ -230,9 +230,9 @@
             "type": "string",
             "required": false,
             "default": "right",
-            "inputType": {"type":"Select", "options":["left","right"]},
+            "inputType": {"type":"Select", "options":["left","top","right","bottom"]},
             "title": "Image alignment",
-            "help": "Defines the horizontal alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Right: Image aligned to the right of the text area. The default alignment is `right`."
+            "help": "Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area.The default alignment is `right`."
           },
           "_graphic": {
             "type": "object",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -168,11 +168,13 @@
               "_imageAlignment": {
                 "type": "string",
                 "title": "Image alignment",
-                "description": "Defines the horizontal alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Right: Image aligned to the right of the text area. The default alignment is `right`",
+                "description": "Defines the alignment of the item image in the pop up. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area.The default alignment is `right`.",
                 "default": "right",
                 "enum": [
                   "left",
-                  "right"
+                  "top",
+                  "right",
+                  "bottom"
                 ],
                 "_backboneForms": "Select"
               },

--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -37,6 +37,32 @@ export default function HotgraphicPopup(props) {
         aria-hidden={!_isActive ? true : null}
         >
 
+          {(_imageAlignment === 'left' || _imageAlignment === 'top') &&
+            <div className={classes([
+              'hotgraphic-popup__item-image-container',
+              _graphic.attribution && 'has-attribution'
+            ])}
+            >
+
+              <img
+                className="hotgraphic-popup__item-image"
+                src={_graphic.src}
+                aria-label={_graphic.alt || null}
+                aria-hidden={!_graphic.alt || null}
+              />
+
+              {_graphic.attribution &&
+              <div className="component__attribution hotgraphic-popup__attribution">
+                <div
+                  className="component__attribution-inner hotgraphic-popup__attribution-inner"
+                  dangerouslySetInnerHTML={{ __html: _graphic.attribution }}
+                />
+              </div>
+              }
+
+            </div>
+          }
+
           <div className="hotgraphic-popup__item-content">
             <div className="hotgraphic-popup__item-content-inner">
 
@@ -68,29 +94,31 @@ export default function HotgraphicPopup(props) {
             </div>
           </div>
 
-          <div className={classes([
-            'hotgraphic-popup__item-image-container',
-            _graphic.attribution && 'has-attribution'
-          ])}
-          >
+          {(_imageAlignment === 'right' || _imageAlignment === 'bottom') &&
+            <div className={classes([
+              'hotgraphic-popup__item-image-container',
+              _graphic.attribution && 'has-attribution'
+            ])}
+            >
 
-            <img
-              className="hotgraphic-popup__item-image"
-              src={_graphic.src}
-              aria-label={_graphic.alt || null}
-              aria-hidden={!_graphic.alt || null}
-            />
-
-            {_graphic.attribution &&
-            <div className="component__attribution hotgraphic-popup__attribution">
-              <div
-                className="component__attribution-inner hotgraphic-popup__attribution-inner"
-                dangerouslySetInnerHTML={{ __html: _graphic.attribution }}
+              <img
+                className="hotgraphic-popup__item-image"
+                src={_graphic.src}
+                aria-label={_graphic.alt || null}
+                aria-hidden={!_graphic.alt || null}
               />
-            </div>
-            }
 
-          </div>
+              {_graphic.attribution &&
+              <div className="component__attribution hotgraphic-popup__attribution">
+                <div
+                  className="component__attribution-inner hotgraphic-popup__attribution-inner"
+                  dangerouslySetInnerHTML={{ __html: _graphic.attribution }}
+                />
+              </div>
+              }
+
+            </div>
+          }
 
         </div>
       )}

--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -38,29 +38,11 @@ export default function HotgraphicPopup(props) {
         >
 
           {(_imageAlignment === 'left' || _imageAlignment === 'top') &&
-            <div className={classes([
-              'hotgraphic-popup__item-image-container',
-              _graphic.attribution && 'has-attribution'
-            ])}
-            >
-
-              <img
-                className="hotgraphic-popup__item-image"
-                src={_graphic.src}
-                aria-label={_graphic.alt || null}
-                aria-hidden={!_graphic.alt || null}
-              />
-
-              {_graphic.attribution &&
-              <div className="component__attribution hotgraphic-popup__attribution">
-                <div
-                  className="component__attribution-inner hotgraphic-popup__attribution-inner"
-                  dangerouslySetInnerHTML={{ __html: _graphic.attribution }}
-                />
-              </div>
-              }
-
-            </div>
+          <templates.image {..._graphic}
+            classNamePrefixSeparator='__item-'
+            classNamePrefixes={['component-item', 'hotgraphic-popup']}
+            attributionClassNamePrefixes={['component', 'hotgraphic-popup']}
+          />
           }
 
           <div className="hotgraphic-popup__item-content">
@@ -95,29 +77,11 @@ export default function HotgraphicPopup(props) {
           </div>
 
           {(_imageAlignment === 'right' || _imageAlignment === 'bottom') &&
-            <div className={classes([
-              'hotgraphic-popup__item-image-container',
-              _graphic.attribution && 'has-attribution'
-            ])}
-            >
-
-              <img
-                className="hotgraphic-popup__item-image"
-                src={_graphic.src}
-                aria-label={_graphic.alt || null}
-                aria-hidden={!_graphic.alt || null}
-              />
-
-              {_graphic.attribution &&
-              <div className="component__attribution hotgraphic-popup__attribution">
-                <div
-                  className="component__attribution-inner hotgraphic-popup__attribution-inner"
-                  dangerouslySetInnerHTML={{ __html: _graphic.attribution }}
-                />
-              </div>
-              }
-
-            </div>
+          <templates.image {..._graphic}
+            classNamePrefixSeparator='__item-'
+            classNamePrefixes={['component-item', 'hotgraphic-popup']}
+            attributionClassNamePrefixes={['component', 'hotgraphic-popup']}
+          />
           }
 
         </div>


### PR DESCRIPTION
- Expand popup image `_imageAlignment` to support `top` and `bottom` layout as per Core Notify.
- Make the popup item DOM order match the visual order to meet WCAG success criteria - https://www.w3.org/TR/WCAG20-TECHS/C27.html
- Use Core image partial to reduce code duplication.

**Testing PR**
This requires testing with [Core PR pull/479](https://github.com/adaptlearning/adapt-contrib-core/pull/479) for `classNamePrefixSeparator` support.

Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/289
