### PR TITLE
Update: Item count ARIA updates (fixes #291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ File name (including path) of the image. Path should be relative to the `src` fo
 The alternative text for this image. Assign [alt text](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) to images that convey course content only.
 
 ## Accessibility
-**Hot Graphic** has two elements assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion** and **popupPagination**. These labels are not visible elements. They are utilized by assistive technology such as screen readers. Should the label texts need to be customised, they can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-hotgraphic/blob/master/properties.schema).
+**Hot Graphic** has been assigned a descriptive label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**.
+
+Other descriptive labels are used to provide context of the previous, current and next item. The following attributes are used to provide this functionality: **item**, **previous** and **next**.
+
+These labels are not visible elements. They are utilized by assistive technology (such as screen readers). Should any of these labels need to be customised or translated, they can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-hotgraphic/blob/master/properties.schema) (or Project settings > Globals in the Adapt Authoring Tool).
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ----------------------------

--- a/properties.schema
+++ b/properties.schema
@@ -15,9 +15,9 @@
     "item": {
       "type": "string",
       "title": "Item count label",
-      "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
+      "default": "Item {{itemNumber}} of {{totalItems}}",
       "inputType": "Text",
-      "help": "This is the aria label for each item. Use {{{itemNumber}}} and {{{totalItems}}} in your text to tell the user which item they are viewing and how many items there are in total.",
+      "help": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total.",
       "translatable": true
     },
     "previous": {

--- a/properties.schema
+++ b/properties.schema
@@ -14,9 +14,10 @@
     },
     "item": {
       "type": "string",
-      "title": "Item",
+      "title": "Item count label",
       "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
       "inputType": "Text",
+      "help": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total.",
       "translatable": true
     },
     "previous": {
@@ -39,7 +40,7 @@
       "default": "{{itemNumber}} / {{totalItems}}",
       "inputType": "Text",
       "validators": [],
-      "help": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total.",
+      "help": "This is the item count displayed in the popup. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total.",
       "translatable": true
     }
   },

--- a/properties.schema
+++ b/properties.schema
@@ -17,7 +17,7 @@
       "title": "Item count label",
       "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
       "inputType": "Text",
-      "help": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total.",
+      "help": "This is the aria label for each item. Use {{{itemNumber}}} and {{{totalItems}}} in your text to tell the user which item they are viewing and how many items there are in total.",
       "translatable": true
     },
     "previous": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,7 +32,7 @@
                     "item": {
                       "type": "string",
                       "title": "Item count label",
-                      "description": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total",
+                      "description": "This is the aria label for each item. Use {{{itemNumber}}} and {{{totalItems}}} in your text to tell the user which item they are viewing and how many items there are in total",
                       "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
                       "_adapt": {
                         "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -31,7 +31,8 @@
                     },
                     "item": {
                       "type": "string",
-                      "title": "Item",
+                      "title": "Item count label",
+                      "description": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total",
                       "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
                       "_adapt": {
                         "translatable": true
@@ -56,7 +57,7 @@
                     "popupPagination": {
                       "type": "string",
                       "title": "Popup pagination",
-                      "description": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total",
+                      "description": "This is the item count displayed in the popup. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total",
                       "default": "{{itemNumber}} / {{totalItems}}",
                       "_adapt": {
                         "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -32,8 +32,8 @@
                     "item": {
                       "type": "string",
                       "title": "Item count label",
-                      "description": "This is the aria label for each item. Use {{{itemNumber}}} and {{{totalItems}}} in your text to tell the user which item they are viewing and how many items there are in total",
-                      "default": "Item {{{itemNumber}}} of {{{totalItems}}}",
+                      "description": "This is the aria label for each item. Use {{itemNumber}} and {{totalItems}} in your text to tell the user which item they are viewing and how many items there are in total",
+                      "default": "Item {{itemNumber}} of {{totalItems}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -40,7 +40,7 @@ export default function HotgraphicLayoutPins(props) {
           const visited = _isVisited ? visitedLabel?.trim?.() + '. ' : '';
           const numbered = _useNumberedPins ? (index + 1) + '. ' : '';
           const itemTitle = (_pin.alt || title)?.trim?.() + '. ';
-          const itemCount = compile(globals._components?._hotgraphic?.popupPagination || '', { itemNumber: _index + 1, totalItems: _items.length });
+          const itemCount = compile(globals._components?._hotgraphic?.item || '', { itemNumber: _index + 1, totalItems: _items.length });
           const ariaLabel = `${visited}${numbered}${itemTitle}${itemCount}`;
 
           return (


### PR DESCRIPTION
- Update `.hotgraphic__pin` `aria-label` to use `item` instead of `popupPagination` to set [itemCount](https://github.com/adaptlearning/adapt-contrib-hotgraphic/blob/d4241ec2bcf965a12e25f30bac1fe071eb56ed50/templates/hotgraphicLayoutPins.jsx#L43C71-L43C86). This should now read _"Item one of three"_ instead of _"one slash three"_.

- README accessibility updated to reflect ARIA properties used.

- Schema `help`/`description` text amended to reflect use.

Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/291