### PR TITLE
Fix: Title is required to set notify popup dialog label (fixes #294)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -204,7 +204,7 @@
             "required": true,
             "default": "",
             "inputType": "Text",
-            "validators": [],
+            "validators": ["required"],
             "help": "Title displayed in the popup",
             "translatable": true
           },

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -136,6 +136,10 @@
           "title": "Items",
           "items": {
             "type": "object",
+            "default": {},
+            "required": [
+              "title"
+            ],
             "properties": {
               "title": {
                 "type": "string",


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/294

### Fix
* Set `title` as `required`. Without a title, the popup `dialog` won't be properly identified by assistive technologies.