### PR TITLE
Fix: Set default for _imageAlignment for popup images (fixes #301)

### DIFF
--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -30,7 +30,7 @@ export default function HotgraphicPopup(props) {
           _isRound && 'is-round',
           _isVisited && 'is-visited',
           _isActive && 'is-active',
-          _imageAlignment ? `align-image-${_imageAlignment}` : 'align-image-right'
+          `align-image-${_imageAlignment || 'right'}` 
         ])}
         key={index}
         data-index={index}

--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -37,7 +37,7 @@ export default function HotgraphicPopup(props) {
         aria-hidden={!_isActive ? true : null}
         >
 
-          {(_imageAlignment === 'left' || _imageAlignment === 'top') &&
+          {(_imageAlignment !== 'right' && _imageAlignment !== 'bottom') &&
           <templates.image {..._graphic}
             classNamePrefixSeparator='__item-'
             classNamePrefixes={['component-item', 'hotgraphic-popup']}

--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -30,7 +30,7 @@ export default function HotgraphicPopup(props) {
           _isRound && 'is-round',
           _isVisited && 'is-visited',
           _isActive && 'is-active',
-          `align-image-${_imageAlignment || 'right'}` 
+          _graphic?.src && `align-image-${_imageAlignment || 'right'}`
         ])}
         key={index}
         data-index={index}

--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -30,14 +30,14 @@ export default function HotgraphicPopup(props) {
           _isRound && 'is-round',
           _isVisited && 'is-visited',
           _isActive && 'is-active',
-          _imageAlignment && `align-image-${_imageAlignment}`
+          _imageAlignment ? `align-image-${_imageAlignment}` : 'align-image-right'
         ])}
         key={index}
         data-index={index}
         aria-hidden={!_isActive ? true : null}
         >
 
-          {(_imageAlignment !== 'right' && _imageAlignment !== 'bottom') &&
+          {(_imageAlignment === 'left' || _imageAlignment === 'top') &&
           <templates.image {..._graphic}
             classNamePrefixSeparator='__item-'
             classNamePrefixes={['component-item', 'hotgraphic-popup']}
@@ -76,7 +76,7 @@ export default function HotgraphicPopup(props) {
             </div>
           </div>
 
-          {(_imageAlignment === 'right' || _imageAlignment === 'bottom') &&
+          {(_imageAlignment !== 'left' && _imageAlignment !== 'top') &&
           <templates.image {..._graphic}
             classNamePrefixSeparator='__item-'
             classNamePrefixes={['component-item', 'hotgraphic-popup']}


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/301

### Fix
* Provide a default display of `_imageAlignment: "right"` in the instance `_imageAlignment` isn't set. The [schemas](https://github.com/adaptlearning/adapt-contrib-hotgraphic/blob/d6aec3dbcfe25baf9881cffe3b81990a5955706c/properties.schema#L233) already define a `default` value of `right`.

### Testing
1. In _component.json_, include a Hotgraphic instance containing items with `_imageAlignment` `left`, `right` and blank values. For example:
```
  {
    "_id": "c-130",
    "_parentId": "b-120",
    "_type": "component",
    "_component": "hotgraphic",
    "_classes": "",
    "_layout": "full",
    "title": "Hot Graphic",
    "displayTitle": "Hot Graphic",
    "body": "You can add interactivity to an image by using the <b>Hot Graphic</b>. This component allows you to position icons over an image. When an icon is selected, content associated with its corresponding location is displayed in a window over the image. This component will fall back to a <b>Narrative</b> when viewed on mobile.<br><br>This component is always spanned.",
    "instruction": "Select the icons to find out more.",
    "mobileBody": "This is optional body text that will be shown when viewed on mobile.",
    "mobileInstruction": "Select the plus icon followed by the next arrow to find out more.",
    "_comment": "setCompletionOn = inview | allItems",
    "_setCompletionOn": "allItems",
    "_canCycleThroughPagination": false,
    "_hidePagination": false,
    "_isNarrativeOnMobile": true,
    "_useNumberedPins": false,
    "_useGraphicsAsPins": false,
    "_isRound": false,
    "_graphic": {
      "src": "course/en/images/hotgraphic.png",
      "alt": "",
      "attribution": "Copyright © 2024"
    },
    "_items": [
      {
        "_top": 42,
        "_left": 8.5,
        "title": "Hot Graphic item 1",
        "body": "This is display text associated with item 1.",
        "strapline": "Hot Graphic strapline 1",
        "_imageAlignment": "right",
        "_comment": "Supported classes = 'hide-desktop-image' | 'hide-popup-image'. Additional classes can be used but they must be predefined in one of the Less files",
        "_classes": "",
        "_graphic": {
          "src": "course/en/images/single-width.png",
          "alt": "",
          "_classes": ""
        },
        "_tooltip": {
          "_isEnabled": false,
          "text": "{{ariaLabel}}"
        }
      },
      {
        "_top": 62,
        "_left": 26.5,
        "title": "Hot Graphic item 2",
        "body": "This is display text associated with item 2.",
        "strapline": "Hot Graphic strapline 2",
        "_imageAlignment": "left",
        "_classes": "",
        "_graphic": {
          "src": "course/en/images/single-width.png",
          "alt": "",
          "_classes": ""
        },
        "_tooltip": {
          "_isEnabled": false,
          "text": "{{ariaLabel}}"
        }
      },
      {
        "_top": 62,
        "_left": 49,
        "title": "Hot Graphic item 3",
        "body": "This is display text associated with item 3.",
        "strapline": "Hot Graphic strapline 3",
        "_imageAlignment": "",
        "_classes": "",
        "_graphic": {
          "src": "course/en/images/single-width.png",
          "alt": "",
          "_classes": ""
        },
        "_tooltip": {
          "_isEnabled": false,
          "text": "{{ariaLabel}}"
        }
      }
    ],
    "_pageLevelProgress": {
      "_isEnabled": true,
      "_isCompletionIndicatorEnabled": true
    }
  },
```
2. Review the Hotgraphic in your course and ensure the item popup display matches the `_imageAlignment` value set. The blank value should default to `right` aligned display.


