### PR TITLE
New: Added static tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,22 @@ If set to `true`, the pin icons will be replaced with the item number. Useful if
 ### \_useGraphicsAsPins (boolean):
 If set to `true`, the image specified by `_graphic.src` will be ignored and the popup images specified in `_items[n]._graphic.src` will instead be laid out in a 2 item width grid system. See [example.json](example.json#L79-L115) for a working example. The default is `false`.
 
+### \_hasStaticTooltips (boolean):
+If set to `true`, tooltips (if enabled) will always be shown rather than only on hover.
+
 ### \_isRound (boolean):
 If set to `true`, the popup images will inherit a 50% border radius. Ideal for use with images that are square that are required to be round. The default is `false`.
 
 ### \_tooltip (object):
 
 #### \_isEnabled (boolean):
-When set to `true` the tooltip will be shown on hover over the item. The default is `false`.
+When set to `true` the tooltip will be shown on hover over the item. When `_hasStaticTooltips` is set to `true`, the tooltip will always be shown. The default is `false`.
 
 #### text (string):
 The text to display when the user hovers over the item.
+
+#### \_position (string):
+The tooltip position in relation to the pin. Can be any combination of `top`, `left`, `right`, and `bottom` (e.g. `top left` or `bottom`). The default is `bottom`.
 
 ### \_graphic (object):
 The graphic object that defines the image over which the hot spots are rendered (except when the [_useGraphicsAsPins](#_usegraphicsaspins-boolean) setting is enabled). It contains the following settings:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If set to `true`, the popup images will inherit a 50% border radius. Ideal for u
 When set to `true` the tooltip will be shown on hover over the item. When `_hasStaticTooltips` is set to `true`, the tooltip will always be shown. The default is `false`.
 
 #### text (string):
-The text to display when the user hovers over the item.
+The tooltip text to display for the item.
 
 #### \_position (string):
 The tooltip position in relation to the pin. Can be any combination of `top`, `left`, `right`, and `bottom` (e.g. `top left` or `bottom`). The default is `bottom`.

--- a/example.json
+++ b/example.json
@@ -20,6 +20,7 @@
         "_isNarrativeOnMobile": true,
         "_useNumberedPins": false,
         "_useGraphicsAsPins": false,
+        "_hasStaticTooltips": false,
         "_isRound": false,
         "_graphic": {
             "src": "course/en/images/example.jpg",
@@ -44,7 +45,8 @@
                 },
                 "_tooltip": {
                     "_isEnabled": false,
-                    "text": "{{ariaLabel}}"
+                    "text": "{{ariaLabel}}",
+                    "_position": ""
                 }
             },
             {
@@ -63,7 +65,8 @@
                 },
                 "_tooltip": {
                     "_isEnabled": false,
-                    "text": "{{ariaLabel}}"
+                    "text": "{{ariaLabel}}",
+                    "_position": ""
                 }
             },
             {
@@ -82,7 +85,8 @@
                 },
                 "_tooltip": {
                     "_isEnabled": false,
-                    "text": "{{ariaLabel}}"
+                    "text": "{{ariaLabel}}",
+                    "_position": ""
                 }
             }
         ],

--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -20,7 +20,6 @@ export default class HotgraphicModel extends ItemsComponentModel {
 
       const tooltip = child.get('_tooltip');
       if (!tooltip?._isEnabled) return;
-
       tooltip._id = `hotgraphic-pin-${id}-${index}`;
       const tooltipConfig = {
         _isStatic: hasStaticTooltips,

--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -12,6 +12,7 @@ export default class HotgraphicModel extends ItemsComponentModel {
   setUpItems() {
     super.setUpItems();
     const id = this.get('_id');
+    const hasStaticTooltips = this.get('_hasStaticTooltips') ?? false;
     this.getChildren().forEach((child, index) => {
 
       // Set _pin for the item if undefined
@@ -19,14 +20,23 @@ export default class HotgraphicModel extends ItemsComponentModel {
 
       const tooltip = child.get('_tooltip');
       if (!tooltip?._isEnabled) return;
+
       tooltip._id = `hotgraphic-pin-${id}-${index}`;
       const tooltipConfig = {
+        _isStatic: hasStaticTooltips,
         ...child.toJSON(),
         _classes: [ 'hotgraphic__pin-tooltip' ],
         ...tooltip
       };
       tooltipConfig._position = tooltipConfig._position || 'outside bottom middle middle';
-      tooltips.register(tooltipConfig);
+      const tooltipModel = tooltips.register(tooltipConfig);
+      child.on('change', () => {
+        tooltipModel.set({
+          ...child.toJSON(),
+          _classes: [ 'hotgraphic__pin-tooltip' ],
+          ...tooltip
+        });
+      });
 
     });
   }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -37,7 +37,7 @@
     --adapt-tooltip-arrow: false;
   
     .tooltip__body {
-      color: black;
+      color: @black;
       background-color: transparent;
     }
   }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -70,10 +70,8 @@
   --adapt-tooltip-distance: 0;
   --adapt-tooltip-arrow: false;
 
-  .tooltip {
-    &__body {
-      color: black;
-      background-color: transparent;
-    }
+  .tooltip__body {
+    color: black;
+    background-color: transparent;
   }
 }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -32,6 +32,16 @@
     display: block;
   }
 
+  &__pin-tooltip.is-static {
+    --adapt-tooltip-distance: 0;
+    --adapt-tooltip-arrow: false;
+  
+    .tooltip__body {
+      color: black;
+      background-color: transparent;
+    }
+  }
+
   // Hotgraphic as tiles
   // --------------------------------------------------
   &__tile-item-container {
@@ -62,16 +72,5 @@
 
   &__tile.is-visited .icon {
     .icon-tick;
-  }
-
-}
-
-.hotgraphic__pin-tooltip.is-static {
-  --adapt-tooltip-distance: 0;
-  --adapt-tooltip-arrow: false;
-
-  .tooltip__body {
-    color: black;
-    background-color: transparent;
   }
 }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -19,7 +19,7 @@
   &__pin .icon {
     .icon-pin;
   }
-  
+
   &__pin.is-visited .icon {
     .icon-tick;
   }
@@ -62,5 +62,18 @@
 
   &__tile.is-visited .icon {
     .icon-tick;
+  }
+
+}
+
+.hotgraphic__pin-tooltip.is-static {
+  --adapt-tooltip-distance: 0;
+  --adapt-tooltip-arrow: false;
+
+  .tooltip {
+    &__body {
+      color: black;
+      background-color: transparent;
+    }
   }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -183,6 +183,15 @@
       "validators": [],
       "help": "If enabled, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes"
     },
+    "_hasStaticTooltips": {
+      "type": "boolean",
+      "required": true,
+      "default": false,
+      "title": "Use static tooltips",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "If enabled, tooltips (if themselves enabled) will always be shown rather than only on hover."
+    },
     "_isRound": {
       "type": "boolean",
       "required": false,
@@ -301,6 +310,19 @@
                 "validators": [],
                 "help": "The tooltip text to display on hover over this item",
                 "translatable": true
+              },
+              "_position": {
+                "type": "string",
+                "required": true,
+                "title": "Tooltip position",
+                "help": "The tooltip position in relation to the pin. Defaults to 'bottom'",
+                "enum": ["top", "top right", "right", "bottom right", "bottom", "bottom left", "left", "top left"],
+                "inputType": {
+                  "type": "Select",
+                  "options": ["top", "top right", "right", "bottom right", "bottom", "bottom left", "left", "top left"]
+                },
+                "default": "bottom",
+                "editorOnly": true
               }
             }
           },

--- a/properties.schema
+++ b/properties.schema
@@ -299,7 +299,7 @@
                 "title": "Is enabled?",
                 "inputType": "Checkbox",
                 "validators": [],
-                "help": "If enabled, a tooltip will be displayed on hover over this item."
+                "help": "If enabled, a tooltip will be displayed on hover over this item. If 'Use static tooltips' is enabled, then tooltips will always be shown."
               },
               "text": {
                 "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -308,7 +308,7 @@
                 "title": "Tooltip text",
                 "inputType": "Text",
                 "validators": [],
-                "help": "The tooltip text to display on hover over this item",
+                "help": "The tooltip text to display for this item",
                 "translatable": true
               },
               "_position": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -288,7 +288,7 @@
                     "type": "string",
                     "default": "{{ariaLabel}}",
                     "title": "Tooltip text",
-                    "description": "The tooltip text to display on hover over this item",
+                    "description": "The tooltip text to display for this item",
                     "translatable": true
                   },
                   "_position": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -282,7 +282,7 @@
                     "type": "boolean",
                     "default": false,
                     "title": "Is enabled?",
-                    "description": "If enabled, a tooltip will be displayed on hover over this item."
+                    "description": "If enabled, a tooltip will be displayed on hover over this item. If 'Use static tooltips' is enabled, then tooltips will always be shown."
                   },
                   "text": {
                     "type": "string",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -125,6 +125,12 @@
           "description": "If enabled, the main graphic will be hidden and pins will be displayed as images which can be positioned using classes",
           "default": false
         },
+        "_hasStaticTooltips": {
+          "type": "boolean",
+          "title": "Use static tooltips",
+          "description": "If enabled, tooltips (if themselves enabled) will always be shown rather than only on hover.",
+          "default": false
+        },
         "_isRound": {
           "type": "boolean",
           "title": "Use circular popup item images",
@@ -276,14 +282,33 @@
                     "type": "boolean",
                     "default": false,
                     "title": "Is enabled?",
-                    "help": "If enabled, a tooltip will be displayed on hover over this item."
+                    "description": "If enabled, a tooltip will be displayed on hover over this item."
                   },
                   "text": {
                     "type": "string",
                     "default": "{{ariaLabel}}",
                     "title": "Tooltip text",
-                    "help": "The tooltip text to display on hover over this item",
+                    "description": "The tooltip text to display on hover over this item",
                     "translatable": true
+                  },
+                  "_position": {
+                    "type": "string",
+                    "title": "Tooltip position",
+                    "default": "bottom",
+                    "description": "The tooltip position in relation to the pin. Defaults to 'bottom'",
+                    "enum": [
+                      "top",
+                      "top right",
+                      "right",
+                      "bottom right",
+                      "bottom",
+                      "bottom left",
+                      "left",
+                      "top left"
+                    ],
+                    "_adapt": {
+                      "editorOnly": true
+                    }
                   }
                 }
               }


### PR DESCRIPTION
fixes #303 

### New
* Added `_useStaticTooltips` and `item._tooltip._position` for labelling pins

### Testing
1. Use core [issue/528](https://github.com/adaptlearning/adapt-contrib-core/pull/529)
```sh
git clone https://github.com/adaptlearning/adapt_framework 528-static-tooltips
cd 528-static-tooltips
npm install && adapt devinstall
cd src/core
git checkout issue/528
cd ../../src/components/adapt-contrib-hotgraphic
git checkout issue/303
cd ../../..
grunt dev
```
2. Edit the hotgraphic component to add
```json
{
    "_hasStaticTooltips": true,
    "_isNarrativeOnMobile": false,
    "_items": [
      {
       "_tooltip": {
          "_isEnabled": true,
          "title": "Name",
          "_position": "top"
          
          "_COMMENT_position": "can be any combination of top left right bottom"
        }
      }
    ]
}
```
3. Run `grunt dev`

It should look like this:
![image](https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7974663/ba0be59c-7f06-462d-95dc-8d8043043e96)
![image](https://github.com/adaptlearning/adapt-contrib-hotgraphic/assets/7974663/60fa39b6-ede7-4263-b6cb-1c0af09ae737)
