### PR TITLE
Fix: Add missing properties (fixes #305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ When set to `true`, hides the "previous" and "next" icons and progress indicator
 When set to `false` the Hotgraphic will render a scaled down 'desktop' version (pins over image / tiles) of the component in mobile view instead of being replaced by a Narrative interaction. The default is `true`.
 
 ### \_isMobileTextBelowImage (boolean):
-If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. When using `_isStackedOnMobile: true`, this attribute will be ignored. The default value is `false`
+If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. When using `_isStackedOnMobile: true` or `_isNarrativeOnMobile: false`, this attribute will be ignored. The default value is `false`
 
 ### \_isStackedOnMobile (boolean):
-If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. When disabled, the strapline mobile layout will be used. The default value is `false`
+If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. `_isNarrativeOnMobile` must be set to `true`. When disabled, the strapline mobile layout will be used. The default value is `false`
 
 ### \_useNumberedPins (boolean):
 If set to `true`, the pin icons will be replaced with the item number. Useful if you want pins to be visited in a set order or show steps in a process. The default is `false`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ When set to `true`, hides the "previous" and "next" icons and progress indicator
 ### \_isNarrativeOnMobile (boolean):
 When set to `false` the Hotgraphic will render a scaled down 'desktop' version (pins over image / tiles) of the component in mobile view instead of being replaced by a Narrative interaction. The default is `true`.
 
+### \_isMobileTextBelowImage (boolean):
+If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. When using `_isStackedOnMobile: true`, this attribute will be ignored. The default value is `false`
+
+### \_isStackedOnMobile (boolean):
+If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. When disabled, the strapline mobile layout will be used. The default value is `false`
+
 ### \_useNumberedPins (boolean):
 If set to `true`, the pin icons will be replaced with the item number. Useful if you want pins to be visited in a set order or show steps in a process. The default is `false`.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ When set to `false` the Hotgraphic will render a scaled down 'desktop' version (
 If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. When using `_isStackedOnMobile: true` or `_isNarrativeOnMobile: false`, this attribute will be ignored. The default value is `false`
 
 ### \_isStackedOnMobile (boolean):
-If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. `_isNarrativeOnMobile` must be set to `true`. When disabled, the strapline mobile layout will be used. The default value is `false`
+If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. `_isNarrativeOnMobile` must be set to `true`. The default value is `false`
 
 ### \_useNumberedPins (boolean):
 If set to `true`, the pin icons will be replaced with the item number. Useful if you want pins to be visited in a set order or show steps in a process. The default is `false`.

--- a/example.json
+++ b/example.json
@@ -18,6 +18,8 @@
         "_canCycleThroughPagination": false,
         "_hidePagination": false,
         "_isNarrativeOnMobile": true,
+        "_isMobileTextBelowImage": false,
+        "_isStackedOnMobile": false,
         "_useNumberedPins": false,
         "_useGraphicsAsPins": false,
         "_isRound": false,

--- a/properties.schema
+++ b/properties.schema
@@ -126,7 +126,7 @@
       "default": "Select the plus icon followed by the next arrow to find out more.",
       "inputType": "Text",
       "validators": [],
-      "help": "This instruction text is displayed on mobile devices",
+      "help": "This instruction text is displayed on mobile devices when this component turns into a Narrative",
       "translatable": true
     },
     "_isNarrativeOnMobile": {

--- a/properties.schema
+++ b/properties.schema
@@ -126,8 +126,17 @@
       "default": "Select the plus icon followed by the next arrow to find out more.",
       "inputType": "Text",
       "validators": [],
-      "help": "This instruction text is displayed on mobile devices when this component turns into a Narrative",
+      "help": "This instruction text is displayed on mobile devices",
       "translatable": true
+    },
+    "_isNarrativeOnMobile": {
+      "type": "boolean",
+      "required": true,
+      "default": true,
+      "title": "Render as Narrative on mobile?",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "If disabled, the Hotgraphic will render a scaled down 'desktop' version (pins over image / tiles) of the component in 'mobile' view instead of being replaced by a Narrative interaction."
     },
     "_isMobileTextBelowImage": {
       "type": "boolean",
@@ -136,7 +145,16 @@
       "title": "Move text area below image on mobile device",
       "inputType": "Checkbox",
       "validators": [],
-      "help": "When Hot Graphic is displayed on a mobile device, it turns into a Narrative. If you check this box, the text content of each stage is positioned below the image. The Narrative will not use the default \"strapline\" layout."
+      "help": "If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. Only applies when the Hot Graphic is configured to render as a Narrative on mobile"
+    },
+    "_isStackedOnMobile": {
+      "type": "boolean",
+      "required": true,
+      "default": false,
+      "title": "Stack images and text on mobile",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. Only applies when the Hot Graphic is configured to render as a Narrative on mobile"
     },
     "_hidePagination": {
       "type": "boolean",
@@ -155,15 +173,6 @@
       "inputType": "Checkbox",
       "validators": [],
       "help": "If enabled, the popup navigation buttons will cycle continuously through the popup items (i.e. clicking next whilst on the last item will cause the first item to be shown."
-    },
-    "_isNarrativeOnMobile": {
-      "type": "boolean",
-      "required": true,
-      "default": true,
-      "title": "Render as Narrative on mobile?",
-      "inputType": "Checkbox",
-      "validators": [],
-      "help": "If disabled, the Hotgraphic will render a scaled down 'desktop' version (pins over image / tiles) of the component in 'mobile' view instead of being replaced by a Narrative interaction."
     },
     "_useNumberedPins": {
       "type": "boolean",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -88,7 +88,7 @@
         "mobileInstruction": {
           "type": "string",
           "title": "Mobile instruction",
-          "description": "This instruction text is displayed on mobile devices when this component turns into a Narrative",
+          "description": "This instruction text is displayed on mobile devices",
           "default": "Select the plus icon followed by the next arrow to find out more.",
           "_adapt": {
             "translatable": true
@@ -112,6 +112,18 @@
           "title": "Replace with Narrative component on mobile",
           "description": "If disabled, the Hotgraphic will render a scaled down 'desktop' version (pins over image / tiles) of the component in 'mobile' view instead of being replaced by a Narrative interaction",
           "default": true
+        },
+        "_isMobileTextBelowImage": {
+          "type": "boolean",
+          "title": "Move text area below image on mobile device",
+          "description": "If enabled, on mobile, the text area drops below the image instead of being behind the strapline button. Only applies when the Hot Graphic is configured to render as a Narrative on mobile",
+          "default": false
+        },
+        "_isStackedOnMobile": {
+          "type": "boolean",
+          "title": "Stack images and text on mobile",
+          "description": "If enabled, on mobile, text and images will be stacked vertically. No interaction will be required to view all items as the user will simply scroll down. Only applies when the Hot Graphic is configured to render as a Narrative on mobile",
+          "default": false
         },
         "_useNumberedPins": {
           "type": "boolean",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -88,7 +88,7 @@
         "mobileInstruction": {
           "type": "string",
           "title": "Mobile instruction",
-          "description": "This instruction text is displayed on mobile devices",
+          "description": "This instruction text is displayed on mobile devices when this component turns into a Narrative",
           "default": "Select the plus icon followed by the next arrow to find out more.",
           "_adapt": {
             "translatable": true


### PR DESCRIPTION
Fixes #305 

### Fix
* Adds `_isMobileTextBelowImage` and `_isStackedOnMobile` where missing in schemas and documentation (see issue description)
* Updates some property descriptions to indicate that they only apply when the Hot Graphic is configured to render as a Narrative on mobile