### PR TITLE
Fix: Allow additional custom classes on tooltips (fixes #316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The tooltip text to display for the item.
 #### \_position (string):
 The tooltip position in relation to the pin. Can be any combination of `top`, `left`, `right`, and `bottom` (e.g. `top left` or `bottom`). The default is `bottom`.
 
+#### \_classes (string):
+CSS class name(s) to be applied to the pin. The class must be predefined in one of the Less files. Separate multiple classes with a space.
+
 ### \_graphic (object):
 The graphic object that defines the image over which the hot spots are rendered (except when the [_useGraphicsAsPins](#_usegraphicsaspins-boolean) setting is enabled). It contains the following settings:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The tooltip text to display for the item.
 The tooltip position in relation to the pin. Can be any combination of `top`, `left`, `right`, and `bottom` (e.g. `top left` or `bottom`). The default is `bottom`.
 
 #### \_classes (string):
-CSS class name(s) to be applied to the pin. The class must be predefined in one of the Less files. Separate multiple classes with a space.
+CSS class name(s) to be applied to the pin tooltip. The class must be predefined in one of the Less files. Separate multiple classes with a space.
 
 ### \_graphic (object):
 The graphic object that defines the image over which the hot spots are rendered (except when the [_useGraphicsAsPins](#_usegraphicsaspins-boolean) setting is enabled). It contains the following settings:

--- a/example.json
+++ b/example.json
@@ -49,6 +49,7 @@
                 "_tooltip": {
                     "_isEnabled": false,
                     "text": "{{ariaLabel}}",
+                    "_classes": "",
                     "_position": ""
                 }
             },
@@ -69,6 +70,7 @@
                 "_tooltip": {
                     "_isEnabled": false,
                     "text": "{{ariaLabel}}",
+                    "_classes": "",
                     "_position": ""
                 }
             },
@@ -89,6 +91,7 @@
                 "_tooltip": {
                     "_isEnabled": false,
                     "text": "{{ariaLabel}}",
+                    "_classes": "",
                     "_position": ""
                 }
             }
@@ -168,7 +171,9 @@
                 },
                 "_tooltip": {
                     "_isEnabled": false,
-                    "text": "{{ariaLabel}}"
+                    "text": "{{ariaLabel}}",
+                    "_classes": "",
+                    "_position": ""
                 },
                 "_pin": {
                     "src": "course/en/images/example.jpg",
@@ -191,7 +196,9 @@
                 },
                 "_tooltip": {
                     "_isEnabled": false,
-                    "text": "{{ariaLabel}}"
+                    "text": "{{ariaLabel}}",
+                    "_classes": "",
+                    "_position": ""
                 },
                 "_pin": {
                     "src": "course/en/images/example.jpg",

--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -22,7 +22,7 @@ export default class HotgraphicModel extends ItemsComponentModel {
       if (!tooltip?._isEnabled) return;
       tooltip._id = `hotgraphic-pin-${id}-${index}`;
       tooltip._classes = [
-        tooltip._classes, 
+        tooltip._classes,
         'hotgraphic__pin-tooltip'
       ].filter(Boolean).join(' ');
       const tooltipConfig = {

--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -21,10 +21,10 @@ export default class HotgraphicModel extends ItemsComponentModel {
       const tooltip = child.get('_tooltip');
       if (!tooltip?._isEnabled) return;
       tooltip._id = `hotgraphic-pin-${id}-${index}`;
+      tooltip._classes = (tooltip._classes || '') + ' hotgraphic__pin-tooltip';
       const tooltipConfig = {
         _isStatic: hasStaticTooltips,
         ...child.toJSON(),
-        _classes: [ 'hotgraphic__pin-tooltip' ],
         ...tooltip
       };
       tooltipConfig._position = tooltipConfig._position || 'outside bottom middle middle';
@@ -32,7 +32,6 @@ export default class HotgraphicModel extends ItemsComponentModel {
       child.on('change', () => {
         tooltipModel.set({
           ...child.toJSON(),
-          _classes: [ 'hotgraphic__pin-tooltip' ],
           ...tooltip
         });
       });

--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -21,7 +21,10 @@ export default class HotgraphicModel extends ItemsComponentModel {
       const tooltip = child.get('_tooltip');
       if (!tooltip?._isEnabled) return;
       tooltip._id = `hotgraphic-pin-${id}-${index}`;
-      tooltip._classes = (tooltip._classes || '') + ' hotgraphic__pin-tooltip';
+      tooltip._classes = [
+        tooltip._classes, 
+        'hotgraphic__pin-tooltip'
+      ].filter(Boolean).join(' ');
       const tooltipConfig = {
         _isStatic: hasStaticTooltips,
         ...child.toJSON(),


### PR DESCRIPTION
Fix #316 

### Fix
* Allows additional custom classes on tooltips

### Testing
1. In a Hot Graphic, set `"_hasStaticTooltips": true`
2. For an item `_tooltip`, add some custom classes:

```
"_tooltip": {
  "_isEnabled": true,
  "text": "{{ariaLabel}}",
  "_classes": "text-white text-larger"
}
```

3. Ensure that the tooltip's style does not change.