### PR TITLE
Update: Add has-numbered-pins class when using numbered pins (fix #320)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ These labels are not visible elements. They are utilized by assistive technology
 
 ----------------------------
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-hotgraphic/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari 14 for macOS/iOS/iPadOS, Opera
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-hotgraphic/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari 14 for macOS/iOS/iPadOS, Opera<br>

--- a/templates/hotgraphic.jsx
+++ b/templates/hotgraphic.jsx
@@ -5,7 +5,6 @@ export default function Hotgraphic(props) {
 
   const {
     _graphic,
-    _useNumberedPins,
     _useGraphicsAsPins
   } = props;
 
@@ -17,7 +16,6 @@ export default function Hotgraphic(props) {
       <div className={classes([
         'component__widget hotgraphic__widget',
         _useGraphicsAsPins ? 'is-tile' : 'is-pin',
-        _useNumberedPins && 'has-numbered-pins',
         _graphic.attribution && 'has-attribution'
       ])}>
 

--- a/templates/hotgraphic.jsx
+++ b/templates/hotgraphic.jsx
@@ -5,6 +5,7 @@ export default function Hotgraphic(props) {
 
   const {
     _graphic,
+    _useNumberedPins,
     _useGraphicsAsPins
   } = props;
 
@@ -16,6 +17,7 @@ export default function Hotgraphic(props) {
       <div className={classes([
         'component__widget hotgraphic__widget',
         _useGraphicsAsPins ? 'is-tile' : 'is-pin',
+        _useNumberedPins && 'has-numbered-pins',
         _graphic.attribution && 'has-attribution'
       ])}>
 

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -54,7 +54,8 @@ export default function HotgraphicLayoutPins(props) {
                   _graphic._classes,
                   _isVisited && 'is-visited',
                   _pin.src && 'has-pin-image',
-                  _pinOffsetOrigin && `offset-origin`
+                  _useNumberedPins && 'is-numbered-pin',
+                  _pinOffsetOrigin && 'offset-origin'
                 ])}
                 data-index={_index}
                 onClick={onPinClicked}


### PR DESCRIPTION
Fixes #320 

### Fix
* Fix typo in PR template
* Add line breaks to readme

### Update
* Adds `is-numbered-pin` class when using numbered pins

### Testing
1. Enable `_useNumberedPins` on a Hot Graphic.
2. Inspect the `.hotgraphic__pin` elements and ensure the new class is present.