### PR TITLE
Update: Add hover and visited image options for pin images (fixes #318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If enabled, on mobile, text and images will be stacked vertically. No interactio
 If set to `true`, the pin icons will be replaced with the item number. Useful if you want pins to be visited in a set order or show steps in a process. The default is `false`.
 
 ### \_useGraphicsAsPins (boolean):
-If set to `true`, the image specified by `_graphic.src` will be ignored and the popup images specified in `_items[n]._graphic.src` will instead be laid out in a 2 item width grid system. See [example.json](example.json#L79-L115) for a working example. The default is `false`.
+If set to `true`, the image specified by `_graphic.src` will be ignored and the popup images specified in `_items[n]._graphic.src` will instead be laid out in a 2 column grid system. See [example.json](example.json) for a working example. The default is `false`.
 
 ### \_hasStaticTooltips (boolean):
 If set to `true`, tooltips (if enabled) will always be shown rather than only on hover.

--- a/example.json
+++ b/example.json
@@ -1,4 +1,4 @@
-    // Regular hotgraphic
+    // Standard Hot Graphic
     // --------------------------------------------------
     {
         "_id": "c-05",
@@ -101,9 +101,9 @@
         }
     }
 
-    // Example using graphics as pins
-    // The following example lays out the item graphics (_items._graphic)
-    // in a 2x2 grid.
+    // Tile / grid layout
+    // This layout uses graphics as pin "tiles" and lays out the 
+    // item graphics (_items._graphic) in a 2 column grid.
     // --------------------------------------------------
     {
         "_useGraphicsAsPins": true,
@@ -149,11 +149,12 @@
         ]
     }
 
-    // Example using graphic pins
-    // In the following example there is a background image and each pin
-    // is an image rather than a pin icon
+    // Graphic pins
+    // This layout uses a background image where each pin item
+    // is an image rather than a pin icon.
     // --------------------------------------------------
     {
+        "_useGraphicsAsPins": false,
         "_items": [
             {
                 "_left": 25,

--- a/example.json
+++ b/example.json
@@ -177,7 +177,9 @@
                     "_position": ""
                 },
                 "_pin": {
-                    "src": "course/en/images/example.jpg",
+                    "src": "course/en/images/pin.png",
+                    "srcHover": "course/en/images/pin-hover.png",
+                    "srcVisited": "course/en/images/pin-visited.png",
                     "alt": ""
                 }
             },
@@ -202,7 +204,9 @@
                     "_position": ""
                 },
                 "_pin": {
-                    "src": "course/en/images/example.jpg",
+                    "src": "course/en/images/pin.png",
+                    "srcHover": "course/en/images/pin-hover.png",
+                    "srcVisited": "course/en/images/pin-visited.png",
                     "alt": ""
                 }
             }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -45,6 +45,39 @@
   }
 }
 
+// Pin image states
+// --------------------------------------------------
+.pin-state-mixin(default, hover, visited);
+.pin-state-mixin(hover, default, visited);
+.pin-state-mixin(visited, default, hover);
+
+.pin-state-mixin(@active-state, @inactive-state-one, @inactive-state-two) {
+  .pin-state.is-@{active-state} {
+    .hotgraphic__pin-image.is-@{active-state} {
+      display: block;
+    }
+
+    .hotgraphic__pin-image.is-@{inactive-state-one},
+    .hotgraphic__pin-image.is-@{inactive-state-two} {
+      display: none;
+    }
+  }
+}
+
+// Application of pin image states
+// --------------------------------------------------
+.hotgraphic__pin.has-pin-image {
+  .pin-state.is-default;
+
+  .no-touch &:hover {
+    .pin-state.is-hover;
+  }
+}
+
+.hotgraphic__pin.has-pin-image.is-visited {
+  .pin-state.is-visited;
+}
+
 // Hotgraphic as tiles
 // --------------------------------------------------
 .hotgraphic__tile-item-container {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -1,80 +1,78 @@
-.hotgraphic {
-  &__widget {
-    position: relative;
+.hotgraphic__widget {
+  position: relative;
+}
+
+// Hotgraphic as pins
+// --------------------------------------------------
+.hotgraphic__pin {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: @icon-padding / 2;
+
+  @media (min-width: @device-width-medium) {
+    padding: @icon-padding;
   }
+}
 
-  // Hotgraphic as pins
-  // --------------------------------------------------
-  &__pin {
-    position: absolute;
-    top: 0;
-    left: 0;
-    padding: @icon-padding / 2;
+.hotgraphic__pin .icon {
+  .icon-pin;
+}
 
-    @media (min-width: @device-width-medium) {
-      padding: @icon-padding;
-    }
+.hotgraphic__pin.is-visited .icon {
+  .icon-tick;
+}
+
+.hotgraphic__pin.offset-origin {
+  .transform(translate(-50%, -50%));
+}
+
+.hotgraphic__pin.has-pin-image {
+  padding: 0;
+}
+
+.hotgraphic__pin-number {
+  display: block;
+}
+
+.hotgraphic__pin-tooltip.is-static {
+  --adapt-tooltip-distance: 0;
+  --adapt-tooltip-arrow: false;
+
+  .tooltip__body {
+    color: @black;
+    background-color: transparent;
   }
+}
 
-  &__pin .icon {
-    .icon-pin;
+// Hotgraphic as tiles
+// --------------------------------------------------
+.hotgraphic__tile-item-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.hotgraphic__tile-item {
+  width: 50%;
+  line-height: 0;
+}
+
+.hotgraphic__tile {
+  position: relative;
+  width: 100%;
+}
+
+.hotgraphic__tile .icon {
+  position: absolute;
+  bottom: 1.0rem;
+  right: 1.0rem;
+  padding: @icon-padding / 2;
+
+  @media (min-width: @device-width-medium) {
+    padding: @icon-padding;
   }
+}
 
-  &__pin.is-visited .icon {
-    .icon-tick;
-  }
-
-  &__pin.offset-origin {
-    .transform(translate(-50%, -50%));
-  }
-
-  &__pin.has-pin-image {
-    padding: 0;
-  }
-
-  &__pin-number {
-    display: block;
-  }
-
-  &__pin-tooltip.is-static {
-    --adapt-tooltip-distance: 0;
-    --adapt-tooltip-arrow: false;
-  
-    .tooltip__body {
-      color: @black;
-      background-color: transparent;
-    }
-  }
-
-  // Hotgraphic as tiles
-  // --------------------------------------------------
-  &__tile-item-container {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  &__tile-item {
-    width: 50%;
-    line-height: 0;
-  }
-
-  &__tile {
-    position: relative;
-    width: 100%;
-  }
-
-  &__tile .icon {
-    position: absolute;
-    bottom: 1.0rem;
-    right: 1.0rem;
-    padding: @icon-padding / 2;
-
-    @media (min-width: @device-width-medium) {
-      padding: @icon-padding;
-    }
-  }
-
-  &__tile.is-visited .icon {
-    .icon-tick;
-  }
+.hotgraphic__tile.is-visited .icon {
+  .icon-tick;
 }

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -66,7 +66,7 @@
 
 // Application of pin image states
 // --------------------------------------------------
-.hotgraphic__pin.has-pin-image {
+.hotgraphic__pin.has-pin-image-states {
   .pin-state.is-default;
 
   .no-touch &:hover {
@@ -74,7 +74,7 @@
   }
 }
 
-.hotgraphic__pin.has-pin-image.is-visited {
+.hotgraphic__pin.has-pin-image-states.is-visited {
   .pin-state.is-visited;
 }
 

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -13,35 +13,35 @@
   @media (min-width: @device-width-medium) {
     padding: @icon-padding;
   }
-}
 
-.hotgraphic__pin .icon {
-  .icon-pin;
-}
+  .icon {
+    .icon-pin;
+  }
 
-.hotgraphic__pin.is-visited .icon {
-  .icon-tick;
-}
+  &.is-visited .icon {
+    .icon-tick;
+  }
 
-.hotgraphic__pin.offset-origin {
-  .transform(translate(-50%, -50%));
-}
+  &.offset-origin {
+    .transform(translate(-50%, -50%));
+  }
 
-.hotgraphic__pin.has-pin-image {
-  padding: 0;
-}
+  &.has-pin-image {
+    padding: 0;
+  }
 
-.hotgraphic__pin-number {
-  display: block;
-}
+  &-number {
+    display: block;
+  }
 
-.hotgraphic__pin-tooltip.is-static {
-  --adapt-tooltip-distance: 0;
-  --adapt-tooltip-arrow: false;
+  &-tooltip.is-static {
+    --adapt-tooltip-distance: 0;
+    --adapt-tooltip-arrow: false;
 
-  .tooltip__body {
-    color: @black;
-    background-color: transparent;
+    .tooltip__body {
+      color: @black;
+      background-color: transparent;
+    }
   }
 }
 
@@ -72,40 +72,40 @@
   .no-touch &:hover {
     .pin-state.is-hover;
   }
-}
 
-.hotgraphic__pin.has-pin-image-states.is-visited {
-  .pin-state.is-visited;
+  &.is-visited {
+    .pin-state.is-visited;
+  }
 }
 
 // Hotgraphic as tiles
 // --------------------------------------------------
-.hotgraphic__tile-item-container {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.hotgraphic__tile-item {
-  width: 50%;
-  line-height: 0;
-}
-
 .hotgraphic__tile {
   position: relative;
   width: 100%;
-}
 
-.hotgraphic__tile .icon {
-  position: absolute;
-  bottom: 1.0rem;
-  right: 1.0rem;
-  padding: @icon-padding / 2;
-
-  @media (min-width: @device-width-medium) {
-    padding: @icon-padding;
+  &-item-container {
+    display: flex;
+    flex-wrap: wrap;
   }
-}
 
-.hotgraphic__tile.is-visited .icon {
-  .icon-tick;
+  &-item {
+    width: 50%;
+    line-height: 0;
+  }
+
+  .icon {
+    position: absolute;
+    bottom: 1.0rem;
+    right: 1.0rem;
+    padding: @icon-padding / 2;
+
+    @media (min-width: @device-width-medium) {
+      padding: @icon-padding;
+    }
+  }
+
+  &.is-visited .icon {
+    .icon-tick;
+  }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -347,7 +347,7 @@
           "_pin": {
             "type": "object",
             "required": false,
-            "title": "Item Pin",
+            "title": "Pin",
             "properties": {
               "src": {
                 "type": "string",
@@ -355,7 +355,26 @@
                 "default": "",
                 "inputType": "Asset:image",
                 "validators": [] ,
-                "help": "This is the pin image, leave blank for default"
+                "title": "Pin image (default)",
+                "help": "This is the pin image. Leave blank to use the default icon."
+              },
+              "srcHover": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": [] ,
+                "title": "Pin image (hover)",
+                "help": "This is the pin image hover state  (optional)."
+              },
+              "srcVisited": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": [] ,
+                "title": "Pin image (visited)",
+                "help": "This is the pin image visited state  (optional)."
               },
               "alt": {
                 "type": "string",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -258,8 +258,28 @@
                   "src": {
                     "type": "string",
                     "isObjectId": true,
-                    "title": "Source",
-                    "description": "This is the pin image, leave blank for default",
+                    "title": "Pin image (default)",
+                    "description": "This is the pin image. Leave blank to use the default icon.",
+                    "_backboneForms": {
+                      "type": "Asset",
+                      "media": "image"
+                    }
+                  },
+                  "srcHover": {
+                    "type": "string",
+                    "isObjectId": true,
+                    "title": "Pin image (hover)",
+                    "description": "This is the pin image hover state (optional).",
+                    "_backboneForms": {
+                      "type": "Asset",
+                      "media": "image"
+                    }
+                  },
+                  "srcVisited": {
+                    "type": "string",
+                    "isObjectId": true,
+                    "title": "Pin image (visited)",
+                    "description": "This is the pin image visited state (optional).",
                     "_backboneForms": {
                       "type": "Asset",
                       "media": "image"

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -70,7 +70,15 @@ export default function HotgraphicLayoutPins(props) {
                   'hotgraphic__pin-image-container',
                   `item-${_index}`
                 ])}>
-                  <img className="hotgraphic__pin-image" src={_pin.src} aria-hidden="true" />
+                  <img className="hotgraphic__pin-image is-default" src={_pin.src} aria-hidden="true" />
+
+                  {_pin.srcHover &&
+                    <img className="hotgraphic__item-image is-hover" src={_pin.srcHover} />
+                  }
+
+                  {_pin.srcVisited &&
+                    <img className="hotgraphic__item-image is-visited" src={_pin.srcVisited} />
+                  }
                 </span>
                 }
 

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -73,11 +73,11 @@ export default function HotgraphicLayoutPins(props) {
                   <img className="hotgraphic__pin-image is-default" src={_pin.src} aria-hidden="true" />
 
                   {_pin.srcHover &&
-                    <img className="hotgraphic__item-image is-hover" src={_pin.srcHover} />
+                    <img className="hotgraphic__pin-image is-hover" src={_pin.srcHover} />
                   }
 
                   {_pin.srcVisited &&
-                    <img className="hotgraphic__item-image is-visited" src={_pin.srcVisited} />
+                    <img className="hotgraphic__pin-image is-visited" src={_pin.srcVisited} />
                   }
                 </span>
                 }

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -54,6 +54,7 @@ export default function HotgraphicLayoutPins(props) {
                   _graphic._classes,
                   _isVisited && 'is-visited',
                   _pin.src && 'has-pin-image',
+                  (_pin.src && _pin.srcHover && _pin.srcVisited) && 'has-pin-image-states',
                   _useNumberedPins && 'is-numbered-pin',
                   _pinOffsetOrigin && 'offset-origin'
                 ])}


### PR DESCRIPTION
Fix #318 

### New
* Adds hover and visited image options to each `_pin`: `srcHover` and `srcVisited`
* Updates schemas and documentation

### Testing
Add hover and visited images to each pin.

```
"_pin": {
  "src": "course/en/images/hotgraphic-pin.png",
  "srcHover": "course/en/images/hotgraphic-pin-hover.png",
  "srcVisited": "course/en/images/hotgraphic-pin-visited.png"
},
```

### Notes
I've created a separate ticket for adding visited state icons. This was previously mentioned on #318 . See #324 