### PR TITLE
Fix: notify aria-labelledby element id (fixes #327)

### DIFF
--- a/templates/hotgraphicPopup.jsx
+++ b/templates/hotgraphicPopup.jsx
@@ -50,10 +50,8 @@ export default function HotgraphicPopup(props) {
 
               {title &&
               <div
-                className={classes([
-                  'hotgraphic-popup__item-title',
-                  _isActive && 'notify-heading'
-                ])}
+                id={_isActive && 'notify-heading'}
+                className="hotgraphic-popup__item-title"
                 role="heading"
                 aria-level={a11y.ariaLevel({ level: 'notify' })}
               >


### PR DESCRIPTION
fixes #327 

### Fix
* Changed 'notify-heading' to id from class such that the `aria-labelledby` on the dialog can find the element