### PR TITLE
Fix: Layout pins attribution as html

### DIFF
--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -30,9 +30,10 @@ export default function HotgraphicLayoutPins(props) {
 
       {_graphic?.attribution &&
       <div className="component__attribution hotgraphic__attribution">
-        <div className="component__attribution-inner hotgraphic__attribution-inner">
-          {_graphic.attribution}
-        </div>
+        <div 
+          className="component__attribution-inner hotgraphic__attribution-inner"
+          dangerouslySetInnerHTML={{ __html: compile(_graphic.attribution, _graphic) }}
+        />
       </div>
       }
 


### PR DESCRIPTION
fixes #333 

### Fix
* Changed attribution text to compiled html


Reference: https://github.com/adaptlearning/adapt-contrib-core/blob/89a0421ba06e127bfb0b5825a2bd7e839e06d49b/templates/image.jsx#L50-L57