### PR TITLE
Fix: Update "Item Popup Classes" schema description to remove align class (fix #335)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -394,7 +394,7 @@
             "title": "Item Popup Classes",
             "inputType": "Text",
             "validators": [],
-            "help": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'align-image-left', 'hide-desktop-image', and 'hide-popup-image' which aligns the item image to the left, hides the pop up image in desktop view, and hides the pop up image for all screen sizes respectively."
+            "help": "Allows you to specify custom CSS classes to be applied to the popup item. 'hide-desktop-image' hides the pop up image in desktop view. 'hide-popup-image' hides the pop up image for all screen sizes."
           },
           "_left": {
             "type": "number",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -299,7 +299,7 @@
               "_classes": {
                 "type": "string",
                 "title": "Popup item custom classes",
-                "description": "Allows you to specify custom CSS classes to be applied to the popup item. Supported classes are 'align-image-left', 'hide-desktop-image', and 'hide-popup-image' which aligns the item image to the left, hides the pop up image in desktop view, and hides the pop up image for all screen sizes respectively",
+                "description": "Allows you to specify custom CSS classes to be applied to the popup item. 'hide-desktop-image' hides the pop up image in desktop view. 'hide-popup-image' hides the pop up image for all screen sizes.",
                 "default": ""
               },
               "_left": {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/335

### Fix
* Update "Item Popup Classes" schema description to remove reference to `align-image-left` class