### PR TITLE
Update: Allow numbered pins when using graphic pins (fix #337)

### DIFF
--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -34,6 +34,13 @@
     display: block;
   }
 
+  &.has-pin-image &-number {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 50%);
+  }
+
   &-tooltip.is-static {
     --adapt-tooltip-distance: 0;
     --adapt-tooltip-arrow: false;

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -86,13 +86,13 @@ export default function HotgraphicLayoutPins(props) {
                 </span>
                 }
 
-                {(!_pin.src && _useNumberedPins && !_isVisited) &&
+                {(_useNumberedPins && !_isVisited) &&
                   <span className="hotgraphic__pin-number" aria-hidden="true">
                     {index + 1}
                   </span>
                 }
 
-                {((!_pin.src && !_useNumberedPins) || (!_pin.src && _isVisited)) &&
+                {(!_useNumberedPins || _isVisited) &&
                   <span className="icon" aria-hidden="true" />
                 }
 


### PR DESCRIPTION
🚧 **Work in progress**

Fix #337 

### Update
* Allow numbered pins when using graphic pins

### Testing
1. In a Hot Graphic, set `_useNumberedPins` to `true`.
2. Add pin images for each item with `_pin.src`
3. `_useGraphicsAsPins` should be set to `false`

### Dependencies
🚧 Will need associated Vanilla PR for the styling.


