### PR TITLE
New: Migration scripts added to repo (fixes #340)

### DIFF
--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,2 +1,0 @@
-import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
-import _ from 'lodash';

--- a/migrations/v2.js
+++ b/migrations/v2.js
@@ -1,0 +1,2 @@
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import _ from 'lodash';

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,22 +1,30 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
-let hotgraphics;
-
 describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
+  let hotgraphics, course, courseHotgraphicGlobals;
   whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-  // mutateContent('Hot Graphic - add _url attribute', async content => {
-  //   hotgraphics.forEach(hotgraphic => { _.set(graphic, '_graphic._url', ''); });
-  //   return true;
-  // });
-  // checkContent('Hot Graphic - check _url attribute', async content => {
-  //   const isValid = hotgraphics.every(({ _graphic }) => _graphic._url !== undefined);
-  //   if (!isValid) throw new Error('Graphic - _graphic._url attribute invalid');
-  //   return true;
-  // });
-  updatePlugin('Hot Graphic - update to vX.X.X', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
+  mutateContent('Hot Graphic - add globals if missing', async (content) => {
+    course = content.find(({ _type }) => _type === 'course');
+    if (!_.has(course, '_globals._components._hotgraphic')) _.set(course, '_globals._components._hotgraphic', {});
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    return true;
+  });
+  mutateContent('Hot Graphic - add popupPagination attribute', async content => {
+    courseHotgraphicGlobals.popupPagination = '{{itemNumber}} / {{totalItems}}';
+    return true;
+  });
+  checkContent('Hot Graphic - check globals _hotgraphic attribute', async content => {
+    if (courseHotgraphicGlobals === undefined) throw new Error('Hot Graphic - globals _hotgraphic invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check globals popupPagination attribute', async content => {
+    if (courseHotgraphicGlobals?.popupPagination === undefined) { throw new Error('Hot Graphic - globals popupPagination invalid'); }
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
 });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,8 +1,6 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
-let hotgraphics;
-
 describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
   whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
@@ -25,7 +23,9 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check globals scrollAriaLabel attribute', async content => {
-    if (courseHotgraphicGlobals?.scrollAriaLabel === undefined) { throw new Error('Hot Graphic - globals scrollAriaLabel invalid'); }
+    if (courseHotgraphicGlobals?.scrollAriaLabel === undefined || courseHotgraphicGlobals.scrollAriaLabel !== '{{itemNumber}} / {{totalItems}}') {
+      throw new Error('Hot Graphic - globals scrollAriaLabel invalid');
+    }
     return true;
   });
   updatePlugin('Hot Graphic - update to vX.X.X', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,2 +1,22 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
+
+let hotgraphics;
+
+describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
+  whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  // mutateContent('Hot Graphic - add _url attribute', async content => {
+  //   hotgraphics.forEach(hotgraphic => { _.set(graphic, '_graphic._url', ''); });
+  //   return true;
+  // });
+  // checkContent('Hot Graphic - check _url attribute', async content => {
+  //   const isValid = hotgraphics.every(({ _graphic }) => _graphic._url !== undefined);
+  //   if (!isValid) throw new Error('Graphic - _graphic._url attribute invalid');
+  //   return true;
+  // });
+  updatePlugin('Hot Graphic - update to vX.X.X', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
+});

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -8,7 +8,7 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
   whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
 
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = getComponents(content, 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
 

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -22,9 +22,9 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
     if (courseHotgraphicGlobals === undefined) throw new Error('Hot Graphic - globals _hotgraphic invalid');
     return true;
   });
-  checkContent('Hot Graphic - check globals scrollAriaLabel attribute', async content => {
-    if (courseHotgraphicGlobals?.scrollAriaLabel !== '{{itemNumber}} / {{totalItems}}') {
-      throw new Error('Hot Graphic - globals scrollAriaLabel invalid');
+  checkContent('Hot Graphic - check globals popupPagination attribute', async content => {
+    if (courseHotgraphicGlobals?.popupPagination !== '{{itemNumber}} / {{totalItems}}') {
+      throw new Error('Hot Graphic - globals popupPagination invalid');
     }
     return true;
   });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,6 +1,8 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
+let hotgraphics;
+
 describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
   whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
@@ -22,9 +24,9 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
     if (courseHotgraphicGlobals === undefined) throw new Error('Hot Graphic - globals _hotgraphic invalid');
     return true;
   });
-  checkContent('Hot Graphic - check globals popupPagination attribute', async content => {
-    if (courseHotgraphicGlobals?.popupPagination === undefined) { throw new Error('Hot Graphic - globals popupPagination invalid'); }
+  checkContent('Hot Graphic - check globals scrollAriaLabel attribute', async content => {
+    if (courseHotgraphicGlobals?.scrollAriaLabel === undefined) { throw new Error('Hot Graphic - globals scrollAriaLabel invalid'); }
     return true;
   });
-  updatePlugin('Hot Graphic - update to v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
+  updatePlugin('Hot Graphic - update to vX.X.X', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
 });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -14,7 +14,7 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
     courseHotgraphicGlobals = course._globals._components._hotgraphic;
     return true;
   });
-  mutateContent('Hot Graphic - add popupPagination attribute', async content => {
+  mutateContent('Hot Graphic - add globals popupPagination attribute', async content => {
     courseHotgraphicGlobals.popupPagination = '{{itemNumber}} / {{totalItems}}';
     return true;
   });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,0 +1,2 @@
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import _ from 'lodash';

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -23,10 +23,10 @@ describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check globals scrollAriaLabel attribute', async content => {
-    if (courseHotgraphicGlobals?.scrollAriaLabel === undefined || courseHotgraphicGlobals.scrollAriaLabel !== '{{itemNumber}} / {{totalItems}}') {
+    if (courseHotgraphicGlobals?.scrollAriaLabel !== '{{itemNumber}} / {{totalItems}}') {
       throw new Error('Hot Graphic - globals scrollAriaLabel invalid');
     }
     return true;
   });
-  updatePlugin('Hot Graphic - update to vX.X.X', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
+  updatePlugin('Hot Graphic - update to v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
 });

--- a/migrations/v3.js
+++ b/migrations/v3.js
@@ -1,32 +1,70 @@
-import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin, testStopWhere, testSuccessWhere, getComponents, getCourse } from 'adapt-migrations';
 import _ from 'lodash';
 
 describe('Hot Graphic - v2.1.2 to v3.0.0', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
+  const popupPagination = '{{itemNumber}} / {{totalItems}}';
+
   whereFromPlugin('Hot Graphic - from v2.1.2', { name: 'adapt-contrib-hotgraphic', version: '<3.0.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents(content, 'hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add globals if missing', async (content) => {
-    course = content.find(({ _type }) => _type === 'course');
-    if (!_.has(course, '_globals._components._hotgraphic')) _.set(course, '_globals._components._hotgraphic', {});
+    course = getCourse();
+    if (!_.has(course, '_globals._components._hotgraphic.popupPagination')) _.set(course, '_globals._components._hotgraphic.popupPagination', popupPagination);
     courseHotgraphicGlobals = course._globals._components._hotgraphic;
     return true;
   });
+
   mutateContent('Hot Graphic - add globals popupPagination attribute', async content => {
-    courseHotgraphicGlobals.popupPagination = '{{itemNumber}} / {{totalItems}}';
+    courseHotgraphicGlobals.popupPagination = popupPagination;
     return true;
   });
+
   checkContent('Hot Graphic - check globals _hotgraphic attribute', async content => {
     if (courseHotgraphicGlobals === undefined) throw new Error('Hot Graphic - globals _hotgraphic invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check globals popupPagination attribute', async content => {
-    if (courseHotgraphicGlobals?.popupPagination !== '{{itemNumber}} / {{totalItems}}') {
+    if (courseHotgraphicGlobals?.popupPagination !== popupPagination) {
       throw new Error('Hot Graphic - globals popupPagination invalid');
     }
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '3.0.0', framework: '>=3.0.0' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '2.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testSuccessWhere('hotgraphic component with empty course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '2.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '2.0.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '3.0.0' }]
+  });
 });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -15,7 +15,9 @@ describe('Hot Graphic - v3.0.0 to v4.0.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check globals ariaPopupLabel', async content => {
-    if (courseHotgraphicGlobals?.ariaPopupLabel !== undefined) throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
+    if (courseHotgraphicGlobals?.ariaPopupLabel !== undefined) {
+      throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
+    }
     return true;
   });
   updatePlugin('Hot Graphic - update to v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '4.0.0', framework: '>=3.3.0' });
@@ -50,29 +52,41 @@ describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add _pin object', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_pin', {}); }); });
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(item => { _.set(item, '_pin', {}); });
+    });
     return true;
   });
   mutateContent('Hot Graphic - add _pin.src attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); }); });
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); });
+    });
     return true;
   });
   mutateContent('Hot Graphic - add _pin.alt attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); }); });
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); });
+    });
     return true;
   });
   checkContent('Hot Graphic - check item _pin attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin !== undefined));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._pin !== undefined);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _pin attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check item _pin.src attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.src !== undefined));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._pin?.src !== undefined);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _pin.src attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check item _pin.alt attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.alt !== undefined));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._pin?.alt !== undefined);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _pin.alt attribute invalid');
     return true;
   });
@@ -87,11 +101,15 @@ describe('Hot Graphic - v4.2.0 to v4.2.1', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { delete item._graphic.title; }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(item => { delete item._graphic.title; });
+    });
     return true;
   });
   checkContent('Hot Graphic - check item _graphic.title', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._graphic.title === undefined));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._graphic.title === undefined);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _graphic.title attribute invalid');
     return true;
   });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -1,117 +1,251 @@
-import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin, getComponents, getCourse, testStopWhere, testSuccessWhere } from 'adapt-migrations';
 import _ from 'lodash';
 
 describe('Hot Graphic - v3.0.1 to v4.0.0', async () => {
-  let hotgraphics, course, courseHotgraphicGlobals;
+  let course, courseHotgraphicGlobals;
+
   whereFromPlugin('Hot Graphic - from v3.0.1', { name: 'adapt-contrib-hotgraphic', version: '<4.0.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
-    return hotgraphics.length;
+    course = getCourse();
+    courseHotgraphicGlobals = course?._globals?._components?._hotgraphic;
+    return courseHotgraphicGlobals?.ariaPopupLabel;
   });
+
   mutateContent('Hot Graphic - remove globals ariaPopupLabel', async (content) => {
-    course = content.find(({ _type }) => _type === 'course');
-    courseHotgraphicGlobals = course._globals._components._hotgraphic;
-    delete courseHotgraphicGlobals.ariaPopupLabel;
+    _.unset(courseHotgraphicGlobals, 'ariaPopupLabel');
     return true;
   });
+
   checkContent('Hot Graphic - check globals ariaPopupLabel', async content => {
-    if (courseHotgraphicGlobals?.ariaPopupLabel !== undefined) {
-      throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
-    }
+    if (courseHotgraphicGlobals?.ariaPopupLabel !== undefined) throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '4.0.0', framework: '>=3.3.0' });
+
+  testSuccessWhere('hotgraphic component with custom course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '3.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: { ariaPopupLabel: 'ariaPopupLabel' } } } }
+    ]
+  });
+
+  testStopWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '3.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('hotgraphic component with empty course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '3.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '3.0.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.0.0' }]
+  });
 });
 
 describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '<4.1.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _setCompletionOn', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_setCompletionOn')) _.set(hotgraphic, '_setCompletionOn', 'allItems');
     });
     return true;
   });
+
   checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._setCompletionOn === 'allItems');
     if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v4.1.0', { name: 'adapt-contrib-hotgraphic', version: '4.1.0', framework: '>=3.3.0' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.0.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.0.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.1.0' }]
+  });
 });
 
 describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v4.1.0', { name: 'adapt-contrib-hotgraphic', version: '<4.2.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _pin object', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(item => { _.set(item, '_pin', {}); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_pin', {}); }); });
     return true;
   });
+
   mutateContent('Hot Graphic - add _pin.src attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); }); });
     return true;
   });
+
   mutateContent('Hot Graphic - add _pin.alt attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); }); });
     return true;
   });
+
   checkContent('Hot Graphic - check item _pin attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._pin !== undefined);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin !== undefined));
     if (!isValid) throw new Error('Hot Graphic - item _pin attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _pin.src attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._pin?.src !== undefined);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.src !== undefined));
     if (!isValid) throw new Error('Hot Graphic - item _pin.src attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _pin.alt attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._pin?.alt !== undefined);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.alt !== undefined));
     if (!isValid) throw new Error('Hot Graphic - item _pin.alt attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '4.2.0', framework: '>=3.3.0' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.1.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.1.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.0' }]
+  });
 });
 
 describe('Hot Graphic - v4.2.0 to v4.2.1', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '<4.2.1' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
     hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(item => { delete item._graphic.title; });
+      _items.forEach(item => { if (_.has(item, '_graphic.title')) _.unset(item, '_graphic.title'); });
     });
     return true;
   });
+
   checkContent('Hot Graphic - check item _graphic.title', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._graphic.title === undefined);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => !_.has(item, '_graphic.title')));
     if (!isValid) throw new Error('Hot Graphic - item _graphic.title attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v4.2.1', { name: 'adapt-contrib-hotgraphic', version: '4.2.1', framework: '>=3.3.0' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.',
+            _graphic: { title: 'Graphic title' }
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.1' }]
+  });
 });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -30,9 +30,7 @@ describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
   });
   mutateContent('Hot Graphic - add _setCompletionOn', async (content) => {
     hotgraphics.forEach(hotgraphic => {
-      if (!_.has(hotgraphic, '_setCompletionOn')) {
-        _.set(hotgraphic, '_setCompletionOn', 'allItems');
-      };
+      if (!_.has(hotgraphic, '_setCompletionOn')) _.set(hotgraphic, '_setCompletionOn', 'allItems');
     });
     return true;
   });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -15,7 +15,7 @@ describe('Hot Graphic - v3.0.0 to v4.0.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check globals ariaPopupLabel', async content => {
-    if (courseHotgraphicGlobals.ariaPopupLabel !== undefined) throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
+    if (courseHotgraphicGlobals?.ariaPopupLabel !== undefined) throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
     return true;
   });
   updatePlugin('Hot Graphic - update to v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '4.0.0', framework: '>=3.3.0' });
@@ -33,7 +33,7 @@ describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== undefined && hotgraphic._setCompletionOn === 'allItems');
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._setCompletionOn === 'allItems');
     if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
     return true;
   });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -1,0 +1,2 @@
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import _ from 'lodash';

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -33,7 +33,7 @@ describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== 'allItems');
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== undefined && hotgraphic._setCompletionOn === 'allItems');
     if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
     return true;
   });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -1,9 +1,9 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
-describe('Hot Graphic - v3.0.0 to v4.0.0', async () => {
+describe('Hot Graphic - v3.0.1 to v4.0.0', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
-  whereFromPlugin('Hot Graphic - from v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '<4.0.0' });
+  whereFromPlugin('Hot Graphic - from v3.0.1', { name: 'adapt-contrib-hotgraphic', version: '<4.0.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -86,3 +86,26 @@ describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
   });
   updatePlugin('Hot Graphic - update to v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '4.2.0', framework: '>=3.3.0' });
 });
+
+describe('Hot Graphic - v4.2.0 to v4.2.1', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '<4.2.1' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(item => {
+        if (_.has(item._graphic, 'title')) { delete item._graphic.title; }
+      });
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check item _graphic.title', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._graphic.title === undefined));
+    if (!isValid) throw new Error('Hot Graphic - item _graphic.title attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v4.2.1', { name: 'adapt-contrib-hotgraphic', version: '4.2.1', framework: '>=3.3.0' });
+});

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -50,21 +50,15 @@ describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add _pin object', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(item => { _.set(item, '_pin', {}); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_pin', {}); }); });
     return true;
   });
   mutateContent('Hot Graphic - add _pin.src attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); }); });
     return true;
   });
   mutateContent('Hot Graphic - add _pin.alt attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); }); });
     return true;
   });
   checkContent('Hot Graphic - check item _pin attribute', async content => {
@@ -94,9 +88,7 @@ describe('Hot Graphic - v4.2.0 to v4.2.1', async () => {
   });
   mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
     hotgraphics.forEach(({ _items }) => {
-      _items.forEach(item => {
-        if (_.has(item._graphic, 'title')) { delete item._graphic.title; }
-      });
+      _items.forEach(item => { if (_.has(item._graphic, 'title')) { delete item._graphic.title; } });
     });
     return true;
   });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -1,2 +1,60 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
+
+describe('Hot Graphic - v3.0.0 to v4.0.0', async () => {
+  let hotgraphics, course, courseHotgraphicGlobals;
+  whereFromPlugin('Hot Graphic - from v3.0.0', { name: 'adapt-contrib-hotgraphic', version: '<4.0.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - remove globals ariaPopupLabel', async (content) => {
+    course = content.find(({ _type }) => _type === 'course');
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    delete courseHotgraphicGlobals.ariaPopupLabel;
+    return true;
+  });
+  checkContent('Hot Graphic - check globals ariaPopupLabel', async content => {
+    if (courseHotgraphicGlobals.ariaPopupLabel !== undefined) throw new Error('Hot Graphic - globals _hotgraphic ariaPopupLabel invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '4.0.0', framework: '>=3.3.0' });
+});
+
+describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v4.0.0', { name: 'adapt-contrib-hotgraphic', version: '<4.1.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - add _setCompletionOn', async (content) => {
+    hotgraphics.forEach(hotgraphic => { _.set(hotgraphic, '_setCompletionOn', 'allItems'); });
+    return true;
+  });
+  checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== 'allItems');
+    if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v4.1.0', { name: 'adapt-contrib-hotgraphic', version: '4.1.0', framework: '>=3.3.0' });
+});
+
+describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v4.1.0', { name: 'adapt-contrib-hotgraphic', version: '<4.2.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  // mutateContent('Hot Graphic - add _pin', async (content) => {
+  //   hotgraphics.forEach(hotgraphic => { _.set(hotgraphic, '_setCompletionOn', 'allItems'); });
+  //   return true;
+  // });
+  // checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
+  //   const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== 'allItems');
+  //   if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
+  //   return true;
+  // });
+  updatePlugin('Hot Graphic - update to v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '4.2.0', framework: '>=3.3.0' });
+});

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -29,7 +29,11 @@ describe('Hot Graphic - v4.0.0 to v4.1.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add _setCompletionOn', async (content) => {
-    hotgraphics.forEach(hotgraphic => { _.set(hotgraphic, '_setCompletionOn', 'allItems'); });
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_setCompletionOn')) {
+        _.set(hotgraphic, '_setCompletionOn', 'allItems');
+      };
+    });
     return true;
   });
   checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
@@ -47,14 +51,38 @@ describe('Hot Graphic - v4.1.0 to v4.2.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-  // mutateContent('Hot Graphic - add _pin', async (content) => {
-  //   hotgraphics.forEach(hotgraphic => { _.set(hotgraphic, '_setCompletionOn', 'allItems'); });
-  //   return true;
-  // });
-  // checkContent('Hot Graphic - check _setCompletionOn attribute', async content => {
-  //   const isValid = hotgraphics.every((hotgraphic) => hotgraphic._setCompletionOn !== 'allItems');
-  //   if (!isValid) throw new Error('Hot Graphic - _setCompletionOn attribute invalid');
-  //   return true;
-  // });
+  mutateContent('Hot Graphic - add _pin object', async (content) => {
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(item => { _.set(item, '_pin', {}); });
+    });
+    return true;
+  });
+  mutateContent('Hot Graphic - add _pin.src attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(({ _pin }) => { _.set(_pin, 'src', ''); });
+    });
+    return true;
+  });
+  mutateContent('Hot Graphic - add _pin.alt attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => {
+      _items.forEach(({ _pin }) => { _.set(_pin, 'alt', ''); });
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check item _pin attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin !== undefined));
+    if (!isValid) throw new Error('Hot Graphic - item _pin attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _pin.src attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.src !== undefined));
+    if (!isValid) throw new Error('Hot Graphic - item _pin.src attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _pin.alt attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.alt !== undefined));
+    if (!isValid) throw new Error('Hot Graphic - item _pin.alt attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v4.2.0', { name: 'adapt-contrib-hotgraphic', version: '4.2.0', framework: '>=3.3.0' });
 });

--- a/migrations/v4.js
+++ b/migrations/v4.js
@@ -87,9 +87,7 @@ describe('Hot Graphic - v4.2.0 to v4.2.1', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      _items.forEach(item => { if (_.has(item._graphic, 'title')) { delete item._graphic.title; } });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { delete item._graphic.title; }); });
     return true;
   });
   checkContent('Hot Graphic - check item _graphic.title', async content => {

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -28,3 +28,45 @@ describe('Hot Graphic - v4.2.1 to v5.0.0', async () => {
   });
   updatePlugin('Hot Graphic - update to v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '5.0.0', framework: '>=5.0.0' });
 });
+
+describe('Hot Graphic - v5.0.0 to v5.2.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '<5.2.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - add _useNumberedPins', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_useNumberedPins')) _.set(hotgraphic, '_useNumberedPins', false);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _useNumberedPins attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._useNumberedPins === false);
+    if (!isValid) throw new Error('Hot Graphic - _useNumberedPins attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v5.2.0', { name: 'adapt-contrib-hotgraphic', version: '5.2.0', framework: '>=5.5.0' });
+});
+
+describe('Hot Graphic - v5.2.0 to v5.3.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v5.2.0', { name: 'adapt-contrib-hotgraphic', version: '<5.3.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - add _isNarrativeOnMobile', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_isNarrativeOnMobile')) _.set(hotgraphic, '_isNarrativeOnMobile', true);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _isNarrativeOnMobile attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isNarrativeOnMobile === true);
+    if (!isValid) throw new Error('Hot Graphic - _isNarrativeOnMobile attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v5.3.0', { name: 'adapt-contrib-hotgraphic', version: '5.3.0', framework: '>=5.5.0' });
+});

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -1,0 +1,2 @@
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import _ from 'lodash';

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -8,7 +8,7 @@ describe('Hot Graphic - v4.2.1 to v5.0.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-  mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
+  mutateContent('Hot Graphic - add _isRound attribute', async (content) => {
     hotgraphics.forEach(hotgraphic => _.set(hotgraphic, '_isRound', false));
     return true;
   });

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -1,2 +1,30 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
+
+describe('Hot Graphic - v4.2.1 to v5.0.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v4.2.1', { name: 'adapt-contrib-hotgraphic', version: '<5.0.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
+    hotgraphics.forEach(hotgraphic => _.set(hotgraphic, '_isRound', false));
+    return true;
+  });
+  mutateContent('Hot Graphic - remove item pinAlt attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => delete item.pinAlt); });
+    return true;
+  });
+  checkContent('Hot Graphic - check _isRound attribute', async content => {
+    const isValid = hotgraphics.every(hotgraphic => hotgraphic?._isRound === false);
+    if (!isValid) throw new Error('Hot Graphic - _isRound attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item pinAlt attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => item?.pinAlt === undefined));
+    if (!isValid) throw new Error('Hot Graphic - item pinAlt attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '5.0.0', framework: '>=5.0.0' });
+});

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -1,9 +1,9 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
-describe('Hot Graphic - v4.2.1 to v5.0.0', async () => {
+describe('Hot Graphic - v4.3.0 to v5.0.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v4.2.1', { name: 'adapt-contrib-hotgraphic', version: '<5.0.0' });
+  whereFromPlugin('Hot Graphic - from v4.3.0', { name: 'adapt-contrib-hotgraphic', version: '<5.0.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -29,9 +29,9 @@ describe('Hot Graphic - v4.2.1 to v5.0.0', async () => {
   updatePlugin('Hot Graphic - update to v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '5.0.0', framework: '>=5.0.0' });
 });
 
-describe('Hot Graphic - v5.0.0 to v5.2.0', async () => {
+describe('Hot Graphic - v5.1.1 to v5.2.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '<5.2.0' });
+  whereFromPlugin('Hot Graphic - from v5.1.1', { name: 'adapt-contrib-hotgraphic', version: '<5.2.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -1,72 +1,169 @@
-import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin, getComponents, testStopWhere, testSuccessWhere } from 'adapt-migrations';
 import _ from 'lodash';
 
 describe('Hot Graphic - v4.3.0 to v5.0.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v4.3.0', { name: 'adapt-contrib-hotgraphic', version: '<5.0.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
-  mutateContent('Hot Graphic - add _isRound attribute', async (content) => {
+
+  mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
     hotgraphics.forEach(hotgraphic => _.set(hotgraphic, '_isRound', false));
     return true;
   });
+
   mutateContent('Hot Graphic - remove item pinAlt attribute', async (content) => {
     hotgraphics.forEach(({ _items }) => { _items.forEach(item => delete item.pinAlt); });
     return true;
   });
+
   checkContent('Hot Graphic - check _isRound attribute', async content => {
     const isValid = hotgraphics.every(hotgraphic => hotgraphic?._isRound === false);
     if (!isValid) throw new Error('Hot Graphic - _isRound attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item pinAlt attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every(item => item?.pinAlt === undefined));
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => {
+      return !_.has(item, 'pinAlt');
+    }));
     if (!isValid) throw new Error('Hot Graphic - item pinAlt attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v5.0.0', { name: 'adapt-contrib-hotgraphic', version: '5.0.0', framework: '>=5.0.0' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.',
+            pinAlt: 'pinAlt 1'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '4.2.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.0.0' }]
+  });
 });
 
 describe('Hot Graphic - v5.1.1 to v5.2.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v5.1.1', { name: 'adapt-contrib-hotgraphic', version: '<5.2.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _useNumberedPins', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_useNumberedPins')) _.set(hotgraphic, '_useNumberedPins', false);
     });
     return true;
   });
+
   checkContent('Hot Graphic - check _useNumberedPins attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._useNumberedPins === false);
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, '_useNumberedPins'));
     if (!isValid) throw new Error('Hot Graphic - _useNumberedPins attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v5.2.0', { name: 'adapt-contrib-hotgraphic', version: '5.2.0', framework: '>=5.5.0' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.1.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic', _useNumberedPins: true },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _id: 'c-110', _component: 'hotgraphic', _useNumberedPins: false },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.1.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.2.0' }]
+  });
 });
 
 describe('Hot Graphic - v5.2.0 to v5.3.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v5.2.0', { name: 'adapt-contrib-hotgraphic', version: '<5.3.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _isNarrativeOnMobile', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_isNarrativeOnMobile')) _.set(hotgraphic, '_isNarrativeOnMobile', true);
     });
     return true;
   });
+
   checkContent('Hot Graphic - check _isNarrativeOnMobile attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isNarrativeOnMobile === true);
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, '_isNarrativeOnMobile'));
     if (!isValid) throw new Error('Hot Graphic - _isNarrativeOnMobile attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v5.3.0', { name: 'adapt-contrib-hotgraphic', version: '5.3.0', framework: '>=5.5.0' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.2.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic', _isNarrativeOnMobile: true },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _id: 'c-110', _component: 'hotgraphic', _isNarrativeOnMobile: false },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.2.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '5.3.0' }]
+  });
 });

--- a/migrations/v5.js
+++ b/migrations/v5.js
@@ -11,7 +11,7 @@ describe('Hot Graphic - v4.3.0 to v5.0.0', async () => {
     return hotgraphics.length;
   });
 
-  mutateContent('Hot Graphic - remove item _graphic.title', async (content) => {
+  mutateContent('Hot Graphic - add _isRound attribute', async (content) => {
     hotgraphics.forEach(hotgraphic => _.set(hotgraphic, '_isRound', false));
     return true;
   });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -95,14 +95,18 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - update instruction ', async (content) => {
-    hotgraphics.forEach(({ instruction }) => {
-      if (instruction === originalInstructionDefault) instruction = 'Select the icons to find out more.';
+    hotgraphics.forEach((hotgraphic) => {
+      if (hotgraphic.instruction === originalInstructionDefault) {
+        hotgraphic.instruction = 'Select the icons to find out more.';
+      }
     });
     return true;
   });
   mutateContent('Hot Graphic - update mobileInstruction ', async (content) => {
-    hotgraphics.forEach(({ mobileInstruction }) => {
-      if (mobileInstruction === originalMobileInstructionDefault) mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
+    hotgraphics.forEach((hotgraphic) => {
+      if (hotgraphic.mobileInstruction === originalMobileInstructionDefault) {
+        hotgraphic.mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
+      }
     });
     return true;
   });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -87,6 +87,8 @@ describe('Hot Graphic - v6.5.0 to v6.5.2', async () => {
 
 describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
   let hotgraphics;
+  const originalInstructionDefault = '';
+  const originalMobileInstructionDefault = '';
   whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
@@ -94,25 +96,23 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
   });
   mutateContent('Hot Graphic - update instruction ', async (content) => {
     hotgraphics.forEach(({ instruction }) => {
-      const originalInstructionDefault = '';
       if (instruction === originalInstructionDefault) instruction = 'Select the icons to find out more.';
     });
     return true;
   });
   mutateContent('Hot Graphic - update mobileInstruction ', async (content) => {
     hotgraphics.forEach(({ mobileInstruction }) => {
-      const originalMobileInstructionDefault = '';
       if (mobileInstruction === originalMobileInstructionDefault) mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
     });
     return true;
   });
   checkContent('Hot Graphic - check instruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.instruction === 'Select the icons to find out more.');
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.instruction !== originalInstructionDefault);
     if (!isValid) throw new Error('Hot Graphic - instruction attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check mobileInstruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.mobileInstruction === 'Select the plus icon followed by the next arrow to find out more.');
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.mobileInstruction !== originalMobileInstructionDefault);
     if (!isValid) throw new Error('Hot Graphic - mobileInstruction attribute invalid');
     return true;
   });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -29,7 +29,15 @@ describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add item _imageAlignment attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_imageAlignment', 'right'); }); });
+    return true;
+  });
+  checkContent('Hot Graphic - check item _imageAlignment attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => item?._imageAlignment === 'right'));
+    if (!isValid) throw new Error('Hot Graphic - item _imageAlignment attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '6.5.0', framework: '>=5.19.1' });
 });
 
@@ -62,7 +70,33 @@ describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add item _tooltip object', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip', {}); }); });
+    return true;
+  });
+  mutateContent('Hot Graphic - add item _tooltip._isEnabled attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_isEnabled', false); }); });
+    return true;
+  });
+  mutateContent('Hot Graphic - add item _tooltip.text attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, 'text', '{{ariaLabel}}'); }); });
+    return true;
+  });
+  checkContent('Hot Graphic - check item _tooltip attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip !== undefined));
+    if (!isValid) throw new Error('Hot Graphic - item _tooltip attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _tooltip._isEnabled attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._isEnabled === false));
+    if (!isValid) throw new Error('Hot Graphic - item _tooltip._isEnabled attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _tooltip.text attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?.text === '{{ariaLabel}}'));
+    if (!isValid) throw new Error('Hot Graphic - item _tooltip.text attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '6.7.0', framework: '>=5.30.2' });
 });
 
@@ -84,7 +118,17 @@ describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add _pinOffsetOrigin', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_pinOffsetOrigin')) _.set(hotgraphic, '_pinOffsetOrigin', false);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _pinOffsetOrigin attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._pinOffsetOrigin === false);
+    if (!isValid) throw new Error('Hot Graphic - _pinOffsetOrigin attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '6.12.0', framework: '>=5.33.10' });
 });
 
@@ -95,7 +139,17 @@ describe('Hot Graphic - v6.12.0 to v6.12.1', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add _isStackedOnMobile', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_isStackedOnMobile')) _.set(hotgraphic, '_isStackedOnMobile', false);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _isStackedOnMobile attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isStackedOnMobile === false);
+    if (!isValid) throw new Error('Hot Graphic - _isStackedOnMobile attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.12.1', { name: 'adapt-contrib-hotgraphic', version: '6.12.1', framework: '>=5.33.10' });
 });
 
@@ -106,7 +160,17 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add _hasStaticTooltips', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_hasStaticTooltips')) _.set(hotgraphic, '_hasStaticTooltips', false);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _hasStaticTooltips attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._hasStaticTooltips === false);
+    if (!isValid) throw new Error('Hot Graphic - _hasStaticTooltips attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '6.13.1', framework: '>=5.39.12' });
 });
 

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -1,2 +1,122 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
+
+describe('Hot Graphic - v5.3.0 to v6.1.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v5.3.0', { name: 'adapt-contrib-hotgraphic', version: '<6.1.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+  mutateContent('Hot Graphic - add _isMobileTextBelowImage', async (content) => {
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, '_isMobileTextBelowImage')) _.set(hotgraphic, '_isMobileTextBelowImage', false);
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check _isMobileTextBelowImage attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isMobileTextBelowImage === false);
+    if (!isValid) throw new Error('Hot Graphic - _isMobileTextBelowImage attribute invalid');
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v6.1.0', { name: 'adapt-contrib-hotgraphic', version: '6.1.0', framework: '>=5.19.1' });
+});
+
+describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.1.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '6.5.0', framework: '>=5.19.1' });
+});
+
+describe('Hot Graphic - v6.5.0 to v6.5.1', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.1' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '6.5.1', framework: '>=5.19.1' });
+});
+
+describe('Hot Graphic - v6.5.1 to v6.6.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '6.6.0', framework: '>=5.19.1' });
+});
+
+describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '<6.7.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '6.7.0', framework: '>=5.30.2' });
+});
+
+describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '<6.11.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '6.11.0', framework: '>=5.33.10' });
+});
+
+describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '6.12.0', framework: '>=5.33.10' });
+});
+
+describe('Hot Graphic - v6.12.0 to v6.12.1', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.1' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.12.1', { name: 'adapt-contrib-hotgraphic', version: '6.12.1', framework: '>=5.33.10' });
+});
+
+describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.12.1', { name: 'adapt-contrib-hotgraphic', version: '<6.13.1' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '6.13.1', framework: '>=5.39.12' });
+});
+
+describe('Hot Graphic - v6.13.1 to v6.15.0', async () => {
+  let hotgraphics;
+  whereFromPlugin('Hot Graphic - from v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '<6.15.0' });
+  whereContent('Hot Graphic - where hotgraphic', async content => {
+    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    return hotgraphics.length;
+  });
+
+  updatePlugin('Hot Graphic - update to v6.15.0', { name: 'adapt-contrib-hotgraphic', version: '6.15.0', framework: '>=5.39.12' });
+});

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -94,13 +94,15 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
   });
   mutateContent('Hot Graphic - update instruction ', async (content) => {
     hotgraphics.forEach(({ instruction }) => {
-      if (instruction === '') instruction = 'Select the icons to find out more.';
+      const originalInstructionDefault = '';
+      if (instruction === originalInstructionDefault) instruction = 'Select the icons to find out more.';
     });
     return true;
   });
   mutateContent('Hot Graphic - update mobileInstruction ', async (content) => {
     hotgraphics.forEach(({ mobileInstruction }) => {
-      if (mobileInstruction === '') mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
+      const originalMobileInstructionDefault = '';
+      if (mobileInstruction === originalMobileInstructionDefault) mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
     });
     return true;
   });
@@ -155,18 +157,30 @@ describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
 });
 
 describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
-  let hotgraphics;
+  let hotgraphics, course, courseHotgraphicGlobals;
   whereFromPlugin('Hot Graphic - from v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '<6.11.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - update globals item attribute', async content => {
+    course = content.find(({ _type }) => _type === 'course');
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    if (courseHotgraphicGlobals?.item === 'Item {{{itemNumber}}} of {{{totalItems}}}') {
+      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
+    }
+    return true;
+  });
+  checkContent('Hot Graphic - check updated globals item attribute', async content => {
+    const isValid = (courseHotgraphicGlobals?.item === 'Item {{itemNumber}} of {{totalItems}}');
+    if (!isValid) throw new Error('Hot Graphic - globals item attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '6.11.0', framework: '>=5.33.10' });
 });
 
 describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
-  let hotgraphics, course, courseHotgraphicGlobals;
+  let hotgraphics;
   whereFromPlugin('Hot Graphic - from v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
@@ -178,22 +192,9 @@ describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
     });
     return true;
   });
-  mutateContent('Hot Graphic - update globals item attribute', async content => {
-    course = content.find(({ _type }) => _type === 'course');
-    courseHotgraphicGlobals = course._globals._components._hotgraphic;
-    if (courseHotgraphicGlobals?.item === 'Item {{{itemNumber}}} of {{{totalItems}}}') {
-      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
-    }
-    return true;
-  });
   checkContent('Hot Graphic - check _pinOffsetOrigin attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._pinOffsetOrigin === false);
     if (!isValid) throw new Error('Hot Graphic - _pinOffsetOrigin attribute invalid');
-    return true;
-  });
-  checkContent('Hot Graphic - check updated globals item attribute', async content => {
-    const isValid = (courseHotgraphicGlobals?.item === 'Item {{itemNumber}} of {{totalItems}}');
-    if (!isValid) throw new Error('Hot Graphic - globals item attribute invalid');
     return true;
   });
   updatePlugin('Hot Graphic - update to v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '6.12.0', framework: '>=5.33.10' });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -1,9 +1,9 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
 import _ from 'lodash';
 
-describe('Hot Graphic - v5.3.0 to v6.1.0', async () => {
+describe('Hot Graphic - v6.0.0 to v6.1.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v5.3.0', { name: 'adapt-contrib-hotgraphic', version: '<6.1.0' });
+  whereFromPlugin('Hot Graphic - from v6.0.0', { name: 'adapt-contrib-hotgraphic', version: '<6.1.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -22,9 +22,9 @@ describe('Hot Graphic - v5.3.0 to v6.1.0', async () => {
   updatePlugin('Hot Graphic - update to v6.1.0', { name: 'adapt-contrib-hotgraphic', version: '6.1.0', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
+describe('Hot Graphic - v6.4.0 to v6.5.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v6.1.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.0' });
+  whereFromPlugin('Hot Graphic - from v6.4.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -45,9 +45,9 @@ describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
   updatePlugin('Hot Graphic - update to v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '6.5.0', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.5.0 to v6.5.2', async () => {
+describe('Hot Graphic - v6.5.1 to v6.5.2', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
-  whereFromPlugin('Hot Graphic - from v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.2' });
+  whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.5.2' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -89,11 +89,11 @@ describe('Hot Graphic - v6.5.0 to v6.5.2', async () => {
   updatePlugin('Hot Graphic - update to v6.5.2', { name: 'adapt-contrib-hotgraphic', version: '6.5.2', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
+describe('Hot Graphic - v6.5.5 to v6.6.0', async () => {
   let hotgraphics;
   const originalInstructionDefault = '';
   const originalMobileInstructionDefault = '';
-  whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
+  whereFromPlugin('Hot Graphic - from v6.5.5', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -131,9 +131,9 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
   updatePlugin('Hot Graphic - update to v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '6.6.0', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
+describe('Hot Graphic - v6.6.4 to v6.7.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '<6.7.0' });
+  whereFromPlugin('Hot Graphic - from v6.6.4', { name: 'adapt-contrib-hotgraphic', version: '<6.7.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -180,9 +180,9 @@ describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
   updatePlugin('Hot Graphic - update to v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '6.7.0', framework: '>=5.30.2' });
 });
 
-describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
+describe('Hot Graphic - v6.10.1 to v6.11.0', async () => {
   let hotgraphics, course, courseHotgraphicGlobals;
-  whereFromPlugin('Hot Graphic - from v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '<6.11.0' });
+  whereFromPlugin('Hot Graphic - from v6.10.1', { name: 'adapt-contrib-hotgraphic', version: '<6.11.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -203,9 +203,9 @@ describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
   updatePlugin('Hot Graphic - update to v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '6.11.0', framework: '>=5.33.10' });
 });
 
-describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
+describe('Hot Graphic - v6.11.3 to v6.12.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
+  whereFromPlugin('Hot Graphic - from v6.11.3', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
@@ -279,9 +279,9 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
   updatePlugin('Hot Graphic - update to v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '6.13.1', framework: '>=5.39.12' });
 });
 
-describe('Hot Graphic - v6.13.1 to v6.15.0', async () => {
+describe('Hot Graphic - v6.14.2 to v6.15.0', async () => {
   let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '<6.15.0' });
+  whereFromPlugin('Hot Graphic - from v6.14.2', { name: 'adapt-contrib-hotgraphic', version: '<6.15.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -1,0 +1,2 @@
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import _ from 'lodash';

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -41,18 +41,51 @@ describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
   updatePlugin('Hot Graphic - update to v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '6.5.0', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.5.0 to v6.5.1', async () => {
-  let hotgraphics;
-  whereFromPlugin('Hot Graphic - from v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.1' });
+describe('Hot Graphic - v6.5.0 to v6.5.2', async () => {
+  let hotgraphics, course, courseHotgraphicGlobals;
+  whereFromPlugin('Hot Graphic - from v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.2' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
-  updatePlugin('Hot Graphic - update to v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '6.5.1', framework: '>=5.19.1' });
+  mutateContent('Hot Graphic - add globals item attribute', async content => {
+    course = content.find(({ _type }) => _type === 'course');
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
+    return true;
+  });
+  mutateContent('Hot Graphic - add globals previous attribute', async content => {
+    courseHotgraphicGlobals.previous = '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}';
+    return true;
+  });
+  mutateContent('Hot Graphic - add globals next attribute', async content => {
+    courseHotgraphicGlobals.next = '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}';
+    return true;
+  });
+  checkContent('Hot Graphic - check globals item attribute', async content => {
+    course = content.find(({ _type }) => _type === 'course');
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    if (courseHotgraphicGlobals?.item !== 'Item {{itemNumber}} of {{totalItems}}') {
+      throw new Error('Hot Graphic - globals item invalid');
+    }
+    return true;
+  });
+  checkContent('Hot Graphic - check globals previous attribute', async content => {
+    if (courseHotgraphicGlobals?.previous !== '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}') {
+      throw new Error('Hot Graphic - globals previous invalid');
+    }
+    return true;
+  });
+  checkContent('Hot Graphic - check globals next attribute', async content => {
+    if (courseHotgraphicGlobals?.next !== '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}') {
+      throw new Error('Hot Graphic - globals next invalid');
+    }
+    return true;
+  });
+  updatePlugin('Hot Graphic - update to v6.5.2', { name: 'adapt-contrib-hotgraphic', version: '6.5.2', framework: '>=5.19.1' });
 });
 
-describe('Hot Graphic - v6.5.1 to v6.6.0', async () => {
+describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
   let hotgraphics;
   whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
@@ -112,7 +145,7 @@ describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
 });
 
 describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
-  let hotgraphics;
+  let hotgraphics, course, courseHotgraphicGlobals;
   whereFromPlugin('Hot Graphic - from v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
   whereContent('Hot Graphic - where hotgraphic', async content => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
@@ -124,9 +157,22 @@ describe('Hot Graphic - v6.11.0 to v6.12.0', async () => {
     });
     return true;
   });
+  mutateContent('Hot Graphic - update globals item attribute', async content => {
+    course = content.find(({ _type }) => _type === 'course');
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    if (courseHotgraphicGlobals?.item === 'Item {{{itemNumber}}} of {{{totalItems}}}') {
+      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
+    }
+    return true;
+  });
   checkContent('Hot Graphic - check _pinOffsetOrigin attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._pinOffsetOrigin === false);
     if (!isValid) throw new Error('Hot Graphic - _pinOffsetOrigin attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check updated globals item attribute', async content => {
+    const isValid = (courseHotgraphicGlobals?.item === 'Item {{itemNumber}} of {{totalItems}}');
+    if (!isValid) throw new Error('Hot Graphic - globals item attribute invalid');
     return true;
   });
   updatePlugin('Hot Graphic - update to v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '6.12.0', framework: '>=5.33.10' });
@@ -166,9 +212,18 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
     });
     return true;
   });
+  mutateContent('Hot Graphic - add item _tooltip._position attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_position', ''); }); });
+    return true;
+  });
   checkContent('Hot Graphic - check _hasStaticTooltips attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._hasStaticTooltips === false);
     if (!isValid) throw new Error('Hot Graphic - _hasStaticTooltips attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _tooltip._position attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._position === ''));
+    if (!isValid) throw new Error('Hot Graphic - item _tooltip._position attribute invalid');
     return true;
   });
   updatePlugin('Hot Graphic - update to v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '6.13.1', framework: '>=5.39.12' });
@@ -181,6 +236,23 @@ describe('Hot Graphic - v6.13.1 to v6.15.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - add _pin.srcHover attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'srcHover', ''); }); });
+    return true;
+  });
+  mutateContent('Hot Graphic - add _pin.srcVisited attribute', async (content) => {
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'srcVisited', ''); }); });
+    return true;
+  });
+  checkContent('Hot Graphic - check item _pin.srcHover attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.srcHover === ''));
+    if (!isValid) throw new Error('Hot Graphic - item _pin.srcHover attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check item _pin.srcVisited attribute', async content => {
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.srcVisited === ''));
+    if (!isValid) throw new Error('Hot Graphic - item _pin.srcVisited attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.15.0', { name: 'adapt-contrib-hotgraphic', version: '6.15.0', framework: '>=5.39.12' });
 });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -384,7 +384,7 @@ describe('Hot Graphic - v6.11.3 to v6.12.0', async () => {
     fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.11.0' }],
     content: [
       { _id: 'c-100', _component: 'hotgraphic' },
-      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+      { _type: 'course', _globals: { _components: { _hotgraphic: { item: originalItem } } } }
     ]
   });
 
@@ -430,7 +430,7 @@ describe('Hot Graphic - v6.12.0 to v6.12.1', async () => {
     fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.12.0' }],
     content: [
       { _id: 'c-100', _component: 'hotgraphic' },
-      { _id: 'c-105', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic', _isStackedOnMobile: false },
       { _type: 'course' }
     ]
   });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -30,11 +30,15 @@ describe('Hot Graphic - v6.1.0 to v6.5.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add item _imageAlignment attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_imageAlignment', 'right'); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(item => { _.set(item, '_imageAlignment', 'right'); });
+    });
     return true;
   });
   checkContent('Hot Graphic - check item _imageAlignment attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every(item => item?._imageAlignment === 'right'));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every(item => item?._imageAlignment === 'right');
+    });
     if (!isValid) throw new Error('Hot Graphic - item _imageAlignment attribute invalid');
     return true;
   });
@@ -111,12 +115,16 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
     return true;
   });
   checkContent('Hot Graphic - check instruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.instruction !== originalInstructionDefault);
+    const isValid = hotgraphics.every((hotgraphic) => {
+      return hotgraphic?.instruction !== originalInstructionDefault;
+    });
     if (!isValid) throw new Error('Hot Graphic - instruction attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check mobileInstruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.mobileInstruction !== originalMobileInstructionDefault);
+    const isValid = hotgraphics.every((hotgraphic) => {
+      return hotgraphic?.mobileInstruction !== originalMobileInstructionDefault;
+    });
     if (!isValid) throw new Error('Hot Graphic - mobileInstruction attribute invalid');
     return true;
   });
@@ -131,29 +139,41 @@ describe('Hot Graphic - v6.6.0 to v6.7.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add item _tooltip object', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip', {}); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(item => { _.set(item, '_tooltip', {}); });
+    });
     return true;
   });
   mutateContent('Hot Graphic - add item _tooltip._isEnabled attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_isEnabled', false); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_isEnabled', false); });
+    });
     return true;
   });
   mutateContent('Hot Graphic - add item _tooltip.text attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, 'text', '{{ariaLabel}}'); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, 'text', '{{ariaLabel}}'); });
+    });
     return true;
   });
   checkContent('Hot Graphic - check item _tooltip attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip !== undefined));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._tooltip !== undefined);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _tooltip attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check item _tooltip._isEnabled attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._isEnabled === false));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._tooltip?._isEnabled === false);
+    });
     if (!isValid) throw new Error('Hot Graphic - item _tooltip._isEnabled attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check item _tooltip.text attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?.text === '{{ariaLabel}}'));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._tooltip?.text === '{{ariaLabel}}');
+    });
     if (!isValid) throw new Error('Hot Graphic - item _tooltip.text attribute invalid');
     return true;
   });
@@ -171,7 +191,7 @@ describe('Hot Graphic - v6.7.0 to v6.11.0', async () => {
     course = content.find(({ _type }) => _type === 'course');
     courseHotgraphicGlobals = course._globals._components._hotgraphic;
     if (courseHotgraphicGlobals?.item === 'Item {{{itemNumber}}} of {{{totalItems}}}') {
-      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
+      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}'; // remove extra brackets
     }
     return true;
   });
@@ -239,7 +259,9 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
     return true;
   });
   mutateContent('Hot Graphic - add item _tooltip._position attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_position', ''); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_position', ''); });
+    });
     return true;
   });
   checkContent('Hot Graphic - check _hasStaticTooltips attribute', async content => {
@@ -248,7 +270,9 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
     return true;
   });
   checkContent('Hot Graphic - check item _tooltip._position attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._position === ''));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._tooltip?._position === '');
+    });
     if (!isValid) throw new Error('Hot Graphic - item _tooltip._position attribute invalid');
     return true;
   });
@@ -263,20 +287,28 @@ describe('Hot Graphic - v6.13.1 to v6.15.0', async () => {
     return hotgraphics.length;
   });
   mutateContent('Hot Graphic - add _pin.srcHover attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'srcHover', ''); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(({ _pin }) => { _.set(_pin, 'srcHover', ''); });
+    });
     return true;
   });
   mutateContent('Hot Graphic - add _pin.srcVisited attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _pin }) => { _.set(_pin, 'srcVisited', ''); }); });
+    hotgraphics.forEach(({ _items }) => {
+      return _items.forEach(({ _pin }) => { _.set(_pin, 'srcVisited', ''); });
+    });
     return true;
   });
   checkContent('Hot Graphic - check item _pin.srcHover attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.srcHover === ''));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._pin?.srcHover === '');
+    });
     if (!isValid) throw new Error('Hot Graphic - item _pin.srcHover attribute invalid');
     return true;
   });
   checkContent('Hot Graphic - check item _pin.srcVisited attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._pin?.srcVisited === ''));
+    const isValid = hotgraphics.every(({ _items }) => {
+      return _items.every((item) => item?._pin?.srcVisited === '');
+    });
     if (!isValid) throw new Error('Hot Graphic - item _pin.srcVisited attribute invalid');
     return true;
   });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -1,316 +1,587 @@
-import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin } from 'adapt-migrations';
+import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin, getComponents, getCourse, testStopWhere, testSuccessWhere } from 'adapt-migrations';
 import _ from 'lodash';
 
 describe('Hot Graphic - v6.0.0 to v6.1.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.0.0', { name: 'adapt-contrib-hotgraphic', version: '<6.1.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _isMobileTextBelowImage', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_isMobileTextBelowImage')) _.set(hotgraphic, '_isMobileTextBelowImage', false);
     });
     return true;
   });
+
   checkContent('Hot Graphic - check _isMobileTextBelowImage attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isMobileTextBelowImage === false);
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, '_isMobileTextBelowImage'));
     if (!isValid) throw new Error('Hot Graphic - _isMobileTextBelowImage attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.1.0', { name: 'adapt-contrib-hotgraphic', version: '6.1.0', framework: '>=5.19.1' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.0.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic'
+      },
+      {
+        _id: 'c-105',
+        _component: 'hotgraphic',
+        _isMobileTextBelowImage: false
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.0.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.1.0' }]
+  });
 });
 
 describe('Hot Graphic - v6.4.0 to v6.5.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.4.0', { name: 'adapt-contrib-hotgraphic', version: '<6.5.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add item _imageAlignment attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(item => { _.set(item, '_imageAlignment', 'right'); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_imageAlignment', 'right'); }); });
     return true;
   });
+
   checkContent('Hot Graphic - check item _imageAlignment attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every(item => item?._imageAlignment === 'right');
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => item?._imageAlignment === 'right'));
     if (!isValid) throw new Error('Hot Graphic - item _imageAlignment attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.5.0', { name: 'adapt-contrib-hotgraphic', version: '6.5.0', framework: '>=5.19.1' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.4.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.4.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.0' }]
+  });
 });
 
 describe('Hot Graphic - v6.5.1 to v6.5.2', async () => {
-  let hotgraphics, course, courseHotgraphicGlobals;
+  let course, courseHotgraphicGlobals;
+  const itemGlobal = 'Item {{itemNumber}} of {{totalItems}}';
+  const previousGlobal = '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}';
+  const nextGlobal = '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}';
+
   whereFromPlugin('Hot Graphic - from v6.5.1', { name: 'adapt-contrib-hotgraphic', version: '<6.5.2' });
-  whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
-    return hotgraphics.length;
-  });
+
   mutateContent('Hot Graphic - add globals item attribute', async content => {
-    course = content.find(({ _type }) => _type === 'course');
+    course = getCourse();
+    if (!_.has(course, '_globals._components._hotgraphic')) _.set(course, '_globals._components._hotgraphic', {});
     courseHotgraphicGlobals = course._globals._components._hotgraphic;
-    courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}';
+    courseHotgraphicGlobals.item = itemGlobal;
     return true;
   });
+
   mutateContent('Hot Graphic - add globals previous attribute', async content => {
-    courseHotgraphicGlobals.previous = '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}';
+    courseHotgraphicGlobals.previous = previousGlobal;
     return true;
   });
+
   mutateContent('Hot Graphic - add globals next attribute', async content => {
-    courseHotgraphicGlobals.next = '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}';
+    courseHotgraphicGlobals.next = nextGlobal;
     return true;
   });
+
   checkContent('Hot Graphic - check globals item attribute', async content => {
-    course = content.find(({ _type }) => _type === 'course');
-    courseHotgraphicGlobals = course._globals._components._hotgraphic;
-    if (courseHotgraphicGlobals?.item !== 'Item {{itemNumber}} of {{totalItems}}') {
+    if (courseHotgraphicGlobals?.item !== itemGlobal) {
       throw new Error('Hot Graphic - globals item invalid');
     }
     return true;
   });
+
   checkContent('Hot Graphic - check globals previous attribute', async content => {
-    if (courseHotgraphicGlobals?.previous !== '{{#if title}}Back to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.previous}}{{/if}}') {
+    if (courseHotgraphicGlobals?.previous !== previousGlobal) {
       throw new Error('Hot Graphic - globals previous invalid');
     }
     return true;
   });
+
   checkContent('Hot Graphic - check globals next attribute', async content => {
-    if (courseHotgraphicGlobals?.next !== '{{#if title}}Forward to {{{title}}} (item {{itemNumber}} of {{totalItems}}){{else}}{{_globals._accessibility._ariaLabels.next}}{{/if}}') {
+    if (courseHotgraphicGlobals?.next !== nextGlobal) {
       throw new Error('Hot Graphic - globals next invalid');
     }
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.5.2', { name: 'adapt-contrib-hotgraphic', version: '6.5.2', framework: '>=5.19.1' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testSuccessWhere('hotgraphic component with empty course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.2' }]
+  });
 });
 
 describe('Hot Graphic - v6.5.5 to v6.6.0', async () => {
   let hotgraphics;
-  const originalInstructionDefault = '';
-  const originalMobileInstructionDefault = '';
+  const newInstruction = 'Select the icons to find out more.';
+  const newMobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
+
   whereFromPlugin('Hot Graphic - from v6.5.5', { name: 'adapt-contrib-hotgraphic', version: '<6.6.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - update instruction ', async (content) => {
-    hotgraphics.forEach((hotgraphic) => {
-      if (hotgraphic.instruction === originalInstructionDefault) {
-        hotgraphic.instruction = 'Select the icons to find out more.';
-      }
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, 'instruction')) _.set(hotgraphic, 'instruction', newInstruction);
+      if (hotgraphic.instruction === '') hotgraphic.instruction = newInstruction;
     });
     return true;
   });
+
   mutateContent('Hot Graphic - update mobileInstruction ', async (content) => {
-    hotgraphics.forEach((hotgraphic) => {
-      if (hotgraphic.mobileInstruction === originalMobileInstructionDefault) {
-        hotgraphic.mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
-      }
+    hotgraphics.forEach(hotgraphic => {
+      if (!_.has(hotgraphic, 'mobileInstruction')) _.set(hotgraphic, 'mobileInstruction', newMobileInstruction);
+      if (hotgraphic.mobileInstruction === '') hotgraphic.mobileInstruction = newMobileInstruction;
     });
     return true;
   });
+
   checkContent('Hot Graphic - check instruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => {
-      return hotgraphic?.instruction !== originalInstructionDefault;
-    });
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, 'instruction'));
     if (!isValid) throw new Error('Hot Graphic - instruction attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check mobileInstruction attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => {
-      return hotgraphic?.mobileInstruction !== originalMobileInstructionDefault;
-    });
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, 'mobileInstruction'));
     if (!isValid) throw new Error('Hot Graphic - mobileInstruction attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '6.6.0', framework: '>=5.19.1' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic', instruction: '', mobileInstruction: '' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _id: 'c-110', _component: 'hotgraphic', instruction: 'customInstruction', mobileInstruction: 'custom mobileInstruction' },
+      { _type: 'course' }
+    ]
+  });
+
+  testSuccessWhere('hotgraphic component with empty course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.5.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.6.0' }]
+  });
 });
 
 describe('Hot Graphic - v6.6.4 to v6.7.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.6.4', { name: 'adapt-contrib-hotgraphic', version: '<6.7.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add item _tooltip object', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(item => { _.set(item, '_tooltip', {}); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip', {}); }); });
     return true;
   });
+
   mutateContent('Hot Graphic - add item _tooltip._isEnabled attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_isEnabled', false); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_isEnabled', false); }); });
     return true;
   });
+
   mutateContent('Hot Graphic - add item _tooltip.text attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, 'text', '{{ariaLabel}}'); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(({ _tooltip }) => { _.set(_tooltip, 'text', '{{ariaLabel}}'); }); });
     return true;
   });
+
   checkContent('Hot Graphic - check item _tooltip attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._tooltip !== undefined);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip !== undefined));
     if (!isValid) throw new Error('Hot Graphic - item _tooltip attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _tooltip._isEnabled attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._tooltip?._isEnabled === false);
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._isEnabled === false));
     if (!isValid) throw new Error('Hot Graphic - item _tooltip._isEnabled attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _tooltip.text attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._tooltip?.text === '{{ariaLabel}}');
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?.text === '{{ariaLabel}}'));
     if (!isValid) throw new Error('Hot Graphic - item _tooltip.text attribute invalid');
     return true;
   });
-  updatePlugin('Hot Graphic - update to v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '6.7.0', framework: '>=5.30.2' });
-});
 
-describe('Hot Graphic - v6.10.1 to v6.11.0', async () => {
-  let hotgraphics, course, courseHotgraphicGlobals;
-  whereFromPlugin('Hot Graphic - from v6.10.1', { name: 'adapt-contrib-hotgraphic', version: '<6.11.0' });
-  whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
-    return hotgraphics.length;
+  updatePlugin('Hot Graphic - update to v6.7.0', { name: 'adapt-contrib-hotgraphic', version: '6.7.0', framework: '>=5.30.2' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.6.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
   });
-  mutateContent('Hot Graphic - update globals item attribute', async content => {
-    course = content.find(({ _type }) => _type === 'course');
-    courseHotgraphicGlobals = course._globals._components._hotgraphic;
-    if (courseHotgraphicGlobals?.item === 'Item {{{itemNumber}}} of {{{totalItems}}}') {
-      courseHotgraphicGlobals.item = 'Item {{itemNumber}} of {{totalItems}}'; // remove extra brackets
-    }
-    return true;
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.6.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
   });
-  checkContent('Hot Graphic - check updated globals item attribute', async content => {
-    const isValid = (courseHotgraphicGlobals?.item === 'Item {{itemNumber}} of {{totalItems}}');
-    if (!isValid) throw new Error('Hot Graphic - globals item attribute invalid');
-    return true;
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.7.0' }]
   });
-  updatePlugin('Hot Graphic - update to v6.11.0', { name: 'adapt-contrib-hotgraphic', version: '6.11.0', framework: '>=5.33.10' });
 });
 
 describe('Hot Graphic - v6.11.3 to v6.12.0', async () => {
-  let hotgraphics;
+  let hotgraphics, course, courseHotgraphicGlobals;
+  const originalItem = 'Item {{{itemNumber}}} of {{{totalItems}}}';
+  const updatedItem = 'Item {{itemNumber}} of {{totalItems}}';
+
   whereFromPlugin('Hot Graphic - from v6.11.3', { name: 'adapt-contrib-hotgraphic', version: '<6.12.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _pinOffsetOrigin', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_pinOffsetOrigin')) _.set(hotgraphic, '_pinOffsetOrigin', false);
     });
     return true;
   });
+
+  mutateContent('Hot Graphic - update globals item attribute', async content => {
+    course = getCourse();
+    if (!_.has(course, '_globals._components._hotgraphic.item')) {
+      _.set(course, '_globals._components._hotgraphic.item', updatedItem);
+    }
+    courseHotgraphicGlobals = course._globals._components._hotgraphic;
+    if (courseHotgraphicGlobals.item === originalItem) {
+      courseHotgraphicGlobals.item = updatedItem;
+    }
+    return true;
+  });
+
   checkContent('Hot Graphic - check _pinOffsetOrigin attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._pinOffsetOrigin === false);
     if (!isValid) throw new Error('Hot Graphic - _pinOffsetOrigin attribute invalid');
     return true;
   });
+
+  checkContent('Hot Graphic - check updated globals item attribute', async content => {
+    const isValid = (courseHotgraphicGlobals?.item !== originalItem);
+    if (!isValid) throw new Error('Hot Graphic - globals item attribute invalid');
+    return true;
+  });
+
   updatePlugin('Hot Graphic - update to v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '6.12.0', framework: '>=5.33.10' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.11.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testSuccessWhere('hotgraphic component with empty course._globals', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.11.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _type: 'course', _globals: { _components: { _hotgraphic: {} } } }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.6.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.12.0' }]
+  });
 });
 
 describe('Hot Graphic - v6.12.0 to v6.12.1', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.12.0', { name: 'adapt-contrib-hotgraphic', version: '<6.12.1' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _isStackedOnMobile', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_isStackedOnMobile')) _.set(hotgraphic, '_isStackedOnMobile', false);
     });
     return true;
   });
+
   checkContent('Hot Graphic - check _isStackedOnMobile attribute', async content => {
-    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._isStackedOnMobile === false);
+    const isValid = hotgraphics.every((hotgraphic) => _.has(hotgraphic, '_isStackedOnMobile'));
     if (!isValid) throw new Error('Hot Graphic - _isStackedOnMobile attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.12.1', { name: 'adapt-contrib-hotgraphic', version: '6.12.1', framework: '>=5.33.10' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.12.0' }],
+    content: [
+      { _id: 'c-100', _component: 'hotgraphic' },
+      { _id: 'c-105', _component: 'hotgraphic' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.12.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.12.1' }]
+  });
 });
 
 describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.12.1', { name: 'adapt-contrib-hotgraphic', version: '<6.13.1' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _hasStaticTooltips', async (content) => {
     hotgraphics.forEach(hotgraphic => {
       if (!_.has(hotgraphic, '_hasStaticTooltips')) _.set(hotgraphic, '_hasStaticTooltips', false);
     });
     return true;
   });
+
   mutateContent('Hot Graphic - add item _tooltip._position attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(({ _tooltip }) => { _.set(_tooltip, '_position', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip._position', ''); }); });
     return true;
   });
+
   checkContent('Hot Graphic - check _hasStaticTooltips attribute', async content => {
     const isValid = hotgraphics.every((hotgraphic) => hotgraphic?._hasStaticTooltips === false);
     if (!isValid) throw new Error('Hot Graphic - _hasStaticTooltips attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _tooltip._position attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._tooltip?._position === '');
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._position === ''));
     if (!isValid) throw new Error('Hot Graphic - item _tooltip._position attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.13.1', { name: 'adapt-contrib-hotgraphic', version: '6.13.1', framework: '>=5.39.12' });
+
+  testSuccessWhere('hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.13.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.13.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.13.1' }]
+  });
 });
 
 describe('Hot Graphic - v6.14.2 to v6.15.0', async () => {
   let hotgraphics;
+
   whereFromPlugin('Hot Graphic - from v6.14.2', { name: 'adapt-contrib-hotgraphic', version: '<6.15.0' });
+
   whereContent('Hot Graphic - where hotgraphic', async content => {
-    hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
+    hotgraphics = getComponents('hotgraphic');
     return hotgraphics.length;
   });
+
   mutateContent('Hot Graphic - add _pin.srcHover attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(({ _pin }) => { _.set(_pin, 'srcHover', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => _items.forEach(item => _.set(item, '_pin.srcHover', '')));
     return true;
   });
+
   mutateContent('Hot Graphic - add _pin.srcVisited attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => {
-      return _items.forEach(({ _pin }) => { _.set(_pin, 'srcVisited', ''); });
-    });
+    hotgraphics.forEach(({ _items }) => _items.forEach(item => _.set(item, '_pin.srcVisited', '')));
     return true;
   });
+
   checkContent('Hot Graphic - check item _pin.srcHover attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._pin?.srcHover === '');
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => _.has(item, '_pin.srcHover')));
     if (!isValid) throw new Error('Hot Graphic - item _pin.srcHover attribute invalid');
     return true;
   });
+
   checkContent('Hot Graphic - check item _pin.srcVisited attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => {
-      return _items.every((item) => item?._pin?.srcVisited === '');
-    });
+    const isValid = hotgraphics.every(({ _items }) => _items.every(item => _.has(item, '_pin.srcVisited')));
     if (!isValid) throw new Error('Hot Graphic - item _pin.srcVisited attribute invalid');
     return true;
   });
+
   updatePlugin('Hot Graphic - update to v6.15.0', { name: 'adapt-contrib-hotgraphic', version: '6.15.0', framework: '>=5.39.12' });
+
+  testSuccessWhere('non/configured hotgraphic component with empty course', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.14.0' }],
+    content: [
+      {
+        _id: 'c-100',
+        _component: 'hotgraphic',
+        _items: [
+          {
+            title: 'Hotspot 1 title',
+            body: 'This is display text 1.'
+          },
+          {
+            title: 'Hotspot 2 title',
+            body: 'This is display text 2.'
+          }
+        ]
+      },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('no hotgraphic components', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.14.0' }],
+    content: [
+      { _component: 'other' },
+      { _type: 'course' }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-hotgraphic', version: '6.15.0' }]
+  });
 });

--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -92,7 +92,28 @@ describe('Hot Graphic - v6.5.2 to v6.6.0', async () => {
     hotgraphics = content.filter(({ _component }) => _component === 'hotgraphic');
     return hotgraphics.length;
   });
-
+  mutateContent('Hot Graphic - update instruction ', async (content) => {
+    hotgraphics.forEach(({ instruction }) => {
+      if (instruction === '') instruction = 'Select the icons to find out more.';
+    });
+    return true;
+  });
+  mutateContent('Hot Graphic - update mobileInstruction ', async (content) => {
+    hotgraphics.forEach(({ mobileInstruction }) => {
+      if (mobileInstruction === '') mobileInstruction = 'Select the plus icon followed by the next arrow to find out more.';
+    });
+    return true;
+  });
+  checkContent('Hot Graphic - check instruction attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.instruction === 'Select the icons to find out more.');
+    if (!isValid) throw new Error('Hot Graphic - instruction attribute invalid');
+    return true;
+  });
+  checkContent('Hot Graphic - check mobileInstruction attribute', async content => {
+    const isValid = hotgraphics.every((hotgraphic) => hotgraphic?.mobileInstruction === 'Select the plus icon followed by the next arrow to find out more.');
+    if (!isValid) throw new Error('Hot Graphic - mobileInstruction attribute invalid');
+    return true;
+  });
   updatePlugin('Hot Graphic - update to v6.6.0', { name: 'adapt-contrib-hotgraphic', version: '6.6.0', framework: '>=5.19.1' });
 });
 


### PR DESCRIPTION
Fix #340

Part of https://github.com/adaptlearning/adapt_framework/issues/3631

### New
* Migration scripts added to repo 

### Migration milestones

#### [3.0.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/e6074c8d8db544eba4c30bf4c95e2ec09272850f#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add globals `popupPagination`
- Add globals `ariaPinLabel`. Removed in [4.0.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/717185fec37f94acb2fe80992de07926d20a13d9#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88) so did _not_ include in scripts.

#### [4.0.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/717185fec37f94acb2fe80992de07926d20a13d9#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Remove globals `ariaPopupLabel`
- Add item `_ariaLevel`. Removed in [6.9.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/4abbf3c68fc9d9bdcdb2e4e1e083ca3ba00869db#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88), so did _not_ include in scripts.

#### [4.1.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/48455547f384542f299b98678f825d385ce30204)
- Add `_setCompletionOn`

#### [4.2.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/b93e33c568796d7ab6847e09fd57d4e48572cf5b#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add item `_pin`
  - Add `src`
  - Add `alt`

#### [4.2.1](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/82e9cff4cb5228adf13b3d00d3351113db8af6ad#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Remove `_graphic.title`

#### [5.0.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/d990b95e816c36f65de4d754836122e0ab5adf2a#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add `_isRound`

#### [5.2.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/69bec1b26188052dc66387afe5a82e3679a62132#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add `_useNumberedPins`

#### [5.3.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/12b89c895249388fe513a7fd26a00aa8a6648ca5#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add `_isNarrativeOnMobile`

#### [6.1.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/ea4394d85007ac3a57a8aec0ffabf588fa2035d9)
- Add `_isMobileTextBelowImage`

#### [6.5.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/cf4a464e1bd58959d83cb3c99a22ba1790689faa#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add item `_imageAlignment`

#### [6.5.1](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/1895aa291df668621723dbdcf34ba8980c786b37#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add globals - `item`, `previous`, and `next`. Schemas fixed in [6.5.2](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/7b46fdb82972d858f51927d4d495b360dde06aac), so using 6.5.2 in the migration scripts.

#### [6.7.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/48fd9920604e2d1cc809505fd074cb9317e0ca4b)
- Add item `_tooltip`
  - Add `_isEnabled`
  - Add `text`

#### [6.11.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/3826047c7579b9d3ed8e900994d5cb3a340aded0#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Update globals `item` default

#### [6.12.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/7bcc69684c302f474055f9661421419cb473b287)
- Add `_pinOffsetOrigin`

#### [6.12.1](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/6a1189036d416697e70d253edf7d14b9385f2883)
- Add `_isStackedOnMobile`

#### [6.13.1](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/7831ee36da43c61bfe3326ef10f4ea8d014025c0)
- Add `_hasStaticTooltips`

#### [6.13.1](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/7831ee36da43c61bfe3326ef10f4ea8d014025c0)
- Add item `_tooltip._position`

#### [6.15.0](https://github.com/adaptlearning/adapt-contrib-hotgraphic/commit/101825ca16b1e3713112c850cf28cd06ae7de181#diff-bbbc797064913d6074c5515fadbef42b3c90e0b677002d065500e190e0d3bf88)
- Add item _pin `srcHover` and `srcVisited`

### Upcoming updates
Hopefully, we can include #343 here as well once it is approved.