### PR TITLE
Fix: Add item _tooltip._classes to schemas (fixes #342)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -346,7 +346,7 @@
                 "type": "string",
                 "required": false,
                 "default": "",
-                "title": "Classes",
+                "title": "Tooltip classes",
                 "inputType": "Text",
                 "validators": [],
                 "help": "Allows you to specify custom CSS classes to be applied to the tooltip.",

--- a/properties.schema
+++ b/properties.schema
@@ -341,6 +341,16 @@
                 },
                 "default": "bottom",
                 "editorOnly": true
+              },
+              "_classes": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "title": "Classes",
+                "inputType": "Text",
+                "validators": [],
+                "help": "Allows you to specify custom CSS classes to be applied to the tooltip.",
+                "translatable": false
               }
             }
           },

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -342,6 +342,13 @@
                     "_adapt": {
                       "editorOnly": true
                     }
+                  },
+                  "_classes": {
+                    "type": "string",
+                    "default": "",
+                    "title": "Classes",
+                    "description": "Allows you to specify custom CSS classes to be applied to the tooltip.",
+                    "translatable": false
                   }
                 }
               }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -346,7 +346,7 @@
                   "_classes": {
                     "type": "string",
                     "default": "",
-                    "title": "Classes",
+                    "title": "Tooltip classes",
                     "description": "Allows you to specify custom CSS classes to be applied to the tooltip.",
                     "translatable": false
                   }


### PR DESCRIPTION
Fix #342 

### Fix
* Adds missing item `_tooltip._classes` to schemas

### To do
This will need added to the [migration scripts](https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/341)