### PR TITLE
New: Add class to static tooltip when hovering over pin (fix #347)

### DIFF
--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -5,14 +5,15 @@ export default class HotgraphicModel extends ItemsComponentModel {
 
   defaults() {
     return ItemsComponentModel.resultExtend('defaults', {
-      _canCycleThroughPagination: false
+      _canCycleThroughPagination: false,
+      _hasStaticTooltips: false
     });
   }
 
   setUpItems() {
     super.setUpItems();
     const id = this.get('_id');
-    const hasStaticTooltips = this.get('_hasStaticTooltips') ?? false;
+    const hasStaticTooltips = this.get('_hasStaticTooltips');
     this.getChildren().forEach((child, index) => {
 
       // Set _pin for the item if undefined

--- a/js/hotgraphicView.js
+++ b/js/hotgraphicView.js
@@ -12,6 +12,8 @@ class HotGraphicView extends ComponentView {
     super.initialize(...args);
 
     this.onPinClicked = this.onPinClicked.bind(this);
+    this.onPinHover = this.onPinHover.bind(this);
+    this.onPinLeave = this.onPinLeave.bind(this);
 
     this.setUpViewData();
     this.setUpEventListeners();
@@ -88,12 +90,34 @@ class HotGraphicView extends ComponentView {
     this.setupInviewCompletion('.hotgraphic__widget');
   }
 
-  onPinClicked (e) {
+  onPinClicked(e) {
     const item = this.model.getItem($(e.currentTarget).data('index'));
 
     item.toggleActive(true);
     item.toggleVisited(true);
     this.openPopup();
+  }
+
+  onPinHover(e) {
+    const hasStaticTooltips = this.model.get('_hasStaticTooltips');
+    if (!hasStaticTooltips) return;
+
+    const itemId = this.model.get('_id');
+    const itemIndex = $(e.currentTarget).data('index');
+    const $tooltip = $(`#tooltip-hotgraphic-pin-${itemId}-${itemIndex}.is-static`);
+    if (!$tooltip.length) return;
+    $tooltip.addClass('is-active');
+  }
+
+  onPinLeave(e) {
+    const hasStaticTooltips = this.model.get('_hasStaticTooltips');
+    if (!hasStaticTooltips) return;
+
+    const itemId = this.model.get('_id');
+    const itemIndex = $(e.currentTarget).data('index');
+    const $tooltip = $(`#tooltip-hotgraphic-pin-${itemId}-${itemIndex}.is-static`);
+    if (!$tooltip.length) return;
+    $tooltip.removeClass('is-active');
   }
 
   openPopup() {

--- a/less/hotgraphic.less
+++ b/less/hotgraphic.less
@@ -42,6 +42,7 @@
     transform: translate(-50%, 50%);
   }
 
+  // Static tooltips. Has the class `is-active` when the corresponding pin is hovered over.
   &-tooltip.is-static {
     --adapt-tooltip-distance: 0;
     --adapt-tooltip-arrow: false;

--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -12,7 +12,9 @@ export default function HotgraphicLayoutPins(props) {
     _useNumberedPins,
     _pinOffsetOrigin,
     _tooltip,
-    onPinClicked
+    onPinClicked,
+    onPinHover,
+    onPinLeave
   } = props;
 
   return (
@@ -63,6 +65,8 @@ export default function HotgraphicLayoutPins(props) {
                 ])}
                 data-index={_index}
                 onClick={onPinClicked}
+                onMouseEnter={onPinHover}
+                onMouseLeave={onPinLeave}
                 style={{ top: _top + '%', left: _left + '%' }}
                 data-tooltip-id={_tooltip?._id}
               >


### PR DESCRIPTION
Fix #347 

### Fix
* Adds the class `is-active` to static tooltips when hovering over the corresponding pin

### Testing
1. Enable static tooltips with `"_hasStaticTooltips": true`
2. Enable the `_tooltip` for each item
3. Add test styles to view a hover state. For example:

```
.hotgraphic__pin-tooltip.is-static.is-active .tooltip__body {
  background-color: deepskyblue;
  color: black;
}
```
