### PR TITLE
Update: use alt instead of aria-label for image alternative text (fixes #356)

### DIFF
--- a/templates/hotgraphicLayoutPins.jsx
+++ b/templates/hotgraphicLayoutPins.jsx
@@ -23,9 +23,8 @@ export default function HotgraphicLayoutPins(props) {
       {_graphic &&
       <img
         className="hotgraphic__image"
-        src={_graphic.src}
-        aria-label={_graphic.alt || null}
-        aria-hidden={!_graphic.alt || null}
+        src={_graphic?.src}
+        alt={_graphic?.alt}
         data-tooltip-id={_tooltip?._isEnabled && _tooltip?._id}
       />
       }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/356

### Update
- replace image `aria-label` with `alt`
- remove image `aria-hidden` 

[Testing](https://github.com/adaptlearning/adapt-contrib-core/issues/822#issuecomment-3804968510) confirmed all major screen readers handle `alt` and `aria-label` equivalently and Adapt would benefit from the broader benefits of `alt`. Benefits include:
-  alternative text displayed when image fails to load 
- alternative text retained when copying images into Word or similar tools.

Testing also confirmed an empty alt tag (`alt=""`) is widely supported by screen readers / browsers to ignore an image without the need for `aria-hidden`.

### Related
- Core image template and Notify popup - https://github.com/adaptlearning/adapt-contrib-core/pull/825)
- Boxmenu header image - https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/231
- LanguagePicker image - https://github.com/adaptlearning/adapt-contrib-languagePicker/pull/127
- Tutor feedback image - https://github.com/adaptlearning/adapt-contrib-tutor/pull/123