### PR TITLE
Fix: Preserve resolved tooltip position and classes on item change (fixes #365)

### DIFF
--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -32,11 +32,13 @@ export default class HotgraphicModel extends ItemsComponentModel {
         ...tooltip
       };
       tooltipConfig._position = tooltipConfig._position || 'outside bottom middle middle';
+      tooltip._position = tooltipConfig._position;
       const tooltipModel = tooltips.register(tooltipConfig);
       child.on('change', () => {
         tooltipModel.set({
           ...child.toJSON(),
-          ...tooltip
+          ...tooltip,
+          _classes: tooltipModel.get('_classes')
         });
       });
 


### PR DESCRIPTION
Fixes #365

### Fix
* Tooltip position no longer shifts after an item is visited when `_tooltip._position` is an empty string
* Tooltip `_classes` (e.g. `is-active` from hover) are no longer clobbered when the item model changes

### Summary
When `_tooltip._position` is `""`, `setUpItems()` correctly resolves it to `'outside bottom middle middle'` during initial registration. However, the `child.on('change')` listener re-spreads the original `tooltip` object into the tooltip model on every child attribute change (e.g. `_isVisited`). This overwrites the resolved `_position` with the empty string, causing `TooltipItemView` to fall back to its own default of `'outside bottom middle right'` - shifting the tooltip from `is-middle` to `is-right`.

The same pattern affects `_classes`. The view adds `is-active` to the tooltip model's `_classes` on hover, but the change handler spreads the stale `tooltip._classes` back in, stripping any classes added at runtime.

The fix writes the resolved `_position` back onto the `tooltip` reference (matching the existing mutation pattern for `_id` and `_classes`), and preserves the tooltip model's current `_classes` in the change handler.

### Testing
1. Add a Hot Graphic with tooltips and `_hasStaticTooltips: true`
2. Set `_tooltip._position` to `""` on an item
3. Observe tooltip renders at bottom center
4. Click the pin to visit the item
5. Verify the tooltip remains at bottom center (not bottom right)
6. Hover over a pin and verify `is-active` class appears on the tooltip
7. Repeat with explicit `_position: "bottom"` to confirm no regression

Posted via collaboration with Claude Code