### PR TITLE
Fix: set _tooltip._position migration to schema default 'bottom' (fixes #370)

### DIFF
--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -466,7 +466,7 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
   });
 
   mutateContent('Hot Graphic - add item _tooltip._position attribute', async (content) => {
-    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip._position', ''); }); });
+    hotgraphics.forEach(({ _items }) => { _items.forEach(item => { _.set(item, '_tooltip._position', 'bottom'); }); });
     return true;
   });
 
@@ -477,7 +477,7 @@ describe('Hot Graphic - v6.12.1 to v6.13.1', async () => {
   });
 
   checkContent('Hot Graphic - check item _tooltip._position attribute', async content => {
-    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._position === ''));
+    const isValid = hotgraphics.every(({ _items }) => _items.every((item) => item?._tooltip?._position === 'bottom'));
     if (!isValid) throw new Error('Hot Graphic - item _tooltip._position attribute invalid');
     return true;
   });


### PR DESCRIPTION
Fixes #370

### Fix
- The `v6.12.1 > v6.13.1` migration in `migrations/v6.js` set `_tooltip._position` to an empty string `''`. `_position` was introduced in v6.13.1 already carrying an `enum` and a `"bottom"` default, so `''` is not a permitted value and migrated content fails modern-schema validation (`/_items/N/_tooltip/_position must be equal to one of the allowed values`).
- Set `_position` to the schema default `'bottom'` in both the `mutateContent` and the matching `checkContent`. The migration's own check previously passed only because it asserted the same invalid `''`.

### Testing
1. `grunt migration:test --file=adapt-contrib-hotgraphic`
2. All scenarios pass; migrated items now hold a valid `_position` (`'bottom'`).
