### PR TITLE
Fix: Remove leaked child change listener in HotgraphicModel (fixes #372)

### DIFF
--- a/js/hotgraphicModel.js
+++ b/js/hotgraphicModel.js
@@ -34,7 +34,7 @@ export default class HotgraphicModel extends ItemsComponentModel {
       tooltipConfig._position = tooltipConfig._position || 'outside bottom middle middle';
       tooltip._position = tooltipConfig._position;
       const tooltipModel = tooltips.register(tooltipConfig);
-      child.on('change', () => {
+      this.listenTo(child, 'change', () => {
         tooltipModel.set({
           ...child.toJSON(),
           ...tooltip,


### PR DESCRIPTION
fixes #372 

### Fix
* Replaced `child.on('change', ...)` with `this.listenTo(child, 'change', ...)` in `HotgraphicModel.setUpItems()` so the listener is tracked against the component model and automatically removed via `stopListening()` when the model is torn down, instead of leaking on the child item indefinitely.

### Testing
1. Add a Hot Graphic component with tooltips enabled.
2. Trigger `setUpItems()` multiple times for the same items (e.g. switch language / reset course).
3. Confirm only one `change` listener is attached per item (no growth in event listener count on the child model).
4. Confirm tooltip content still updates correctly when the item's attributes change (position, visited state, classes).